### PR TITLE
V1.1.7 splash scene click through

### DIFF
--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -113,6 +113,12 @@ void Application::ProcessEvents()
         {
             SceneManager::Instance().GetActiveScene()->HandleEvent(event);
         }
+        else
+        {
+            m_isRunning = false;
+
+            return;
+        }
 
         switch (event.type)
         {
@@ -120,31 +126,6 @@ void Application::ProcessEvents()
                 m_isRunning = false;
                 CT_LOG_INFO("Application closing from window close event.");
                 break;
-
-            case sf::Event::KeyPressed:
-                if (event.key.code == sf::Keyboard::Escape)
-                {
-                    m_isRunning = false;
-                    CT_LOG_INFO("Application closing from escape key.");
-                }
-                break;
-
-            case sf::Event::Resized:
-            {
-                auto &window = WindowManager::Instance().GetWindow();
-                sf::FloatRect visibleArea(0, 0, event.size.width, event.size.height);
-                window.setView(sf::View(visibleArea));
-
-                CT_LOG_INFO("Window resized to {}x{}", event.size.width, event.size.height);
-
-                // Optionally notify the scene to reposition UI
-                if (SceneManager::Instance().HasActiveScene())
-                {
-                    SceneManager::Instance().GetActiveScene()->OnResize({event.size.width, event.size.height});
-                }
-
-                break;
-            }
 
             default:
                 break;

--- a/src/core/InputManager.cpp
+++ b/src/core/InputManager.cpp
@@ -142,9 +142,9 @@ bool InputManager::IsKeyPressed(const std::string &action) const
 /// @brief Returns the state of if a key has just been pressed, based on the input action.
 /// @param action determine if the action is bound to key, and if it is just being pressed now.
 /// @return true / false
-bool InputManager::IsJustPressed(const std::string &action) const
+bool InputManager::IsKeyJustPressed(const std::string &action) const
 {
-    CT_WARN_IF_UNINITIALIZED_RET("InputManager", "IsJustPressed", false);
+    CT_WARN_IF_UNINITIALIZED_RET("InputManager", "IsKeyJustPressed", false);
 
     if (!m_keyBindings.contains(action))
     {
@@ -162,9 +162,9 @@ bool InputManager::IsJustPressed(const std::string &action) const
 /// @brief Returns the state of if a key has just been released, based on the input action.
 /// @param action determine if the action is bound to key, and if it is just being released now.
 /// @return true / false
-bool InputManager::IsJustReleased(const std::string &action) const
+bool InputManager::IsKeyJustReleased(const std::string &action) const
 {
-    CT_WARN_IF_UNINITIALIZED_RET("InputManager", "IsJustReleased", false);
+    CT_WARN_IF_UNINITIALIZED_RET("InputManager", "IsKeyJustReleased", false);
 
     if (!m_keyBindings.contains(action))
     {

--- a/src/core/InputManager.h
+++ b/src/core/InputManager.h
@@ -41,8 +41,8 @@ class InputManager
     void PostUpdate();
 
     bool IsKeyPressed(const std::string &action) const;
-    bool IsJustPressed(const std::string &action) const;
-    bool IsJustReleased(const std::string &action) const;
+    bool IsKeyJustPressed(const std::string &action) const;
+    bool IsKeyJustReleased(const std::string &action) const;
 
     sf::Vector2i GetMousePosition() const;
     void SetMousePosition(const sf::Vector2i &position);

--- a/src/core/scenes/GameScene.cpp
+++ b/src/core/scenes/GameScene.cpp
@@ -71,7 +71,7 @@ void GameScene::OnExit()
 // Performs internal state management during a single frame.
 void GameScene::Update(float dt)
 {
-    if (InputManager::Instance().IsJustReleased("MenuSelectBack"))
+    if (InputManager::Instance().IsKeyJustReleased("MenuSelectBack"))
     {
         AudioManager::Instance().StopMusic(true, 1.0f);
         m_shouldExit = true;

--- a/src/core/scenes/MainMenuScene.cpp
+++ b/src/core/scenes/MainMenuScene.cpp
@@ -135,10 +135,19 @@ void MainMenuScene::Update(float dt)
     return;
 }
 
-/// @brief Not used in MainMenuScene context.
+/// @brief Handle any quick cancelation requests if present.
 /// @param event bubbled down from caller, not needed.
 void MainMenuScene::HandleEvent(const sf::Event &event)
 {
+    if (event.type == sf::Event::KeyPressed)
+    {
+        if (event.key.code == sf::Keyboard::Escape)
+        {
+            m_shouldExit = true;
+
+            CT_LOG_INFO("MainMenuScene: Esc event handled.");
+        }
+    }
 }
 
 /// @brief Not used in MainMenuScene context.

--- a/src/core/scenes/MainMenuScene.h
+++ b/src/core/scenes/MainMenuScene.h
@@ -63,5 +63,5 @@ class MainMenuScene final : public Scene
     std::shared_ptr<Settings> m_settings;
     std::unique_ptr<Background> m_background;
     std::shared_ptr<UITextLabel> m_titleLabel;
-    SceneID m_requestedScene = SceneID::Splash;
+    SceneID m_requestedScene;
 };

--- a/src/core/scenes/SplashScene.cpp
+++ b/src/core/scenes/SplashScene.cpp
@@ -86,7 +86,7 @@ void SplashScene::Update(float dt)
     UpdateFadeInOut(dt);
     ApplyShakeEffect(dt);
 
-    if (m_fadingOut && m_fadeTimer >= FADE_OUT_DURATION)
+    if (m_fadingOut && m_fadeTimer >= FADE_OUT_DURATION || m_hasPendingTransition)
     {
         CT_LOG_INFO("SplashScene requesting scene change.");
 
@@ -94,10 +94,20 @@ void SplashScene::Update(float dt)
     }
 }
 
-/// @brief Not used in SplashScene context.
+/// @brief Handle any quick cancelation requests if present.
 /// @param event bubbled down from caller, not needed.
 void SplashScene::HandleEvent(const sf::Event &event)
 {
+    if (event.type == sf::Event::KeyPressed)
+    {
+        if (event.key.code == sf::Keyboard::Escape || event.key.code == sf::Keyboard::Enter ||
+            event.key.code == sf::Keyboard::Space)
+        {
+            m_hasPendingTransition = true;
+
+            CT_LOG_INFO("SplashScene: skip event handled.");
+        }
+    }
 }
 
 /// @brief Not used in SplashScene context.

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 1
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 6
+#define CT_VERSION_PATCH 7
 
 /// @brief String representation for Chaos Theory version.
-#define CT_VERSION_STRING "1.1.6"
+#define CT_VERSION_STRING "1.1.7"

--- a/test/InputManagerTest.cpp
+++ b/test/InputManagerTest.cpp
@@ -75,7 +75,7 @@ TEST_F(InputManagerTest, KeyPressTracking)
     InputManager::Instance().PostUpdate();
 
     EXPECT_TRUE(InputManager::Instance().IsKeyPressed("MoveLeft"));
-    EXPECT_FALSE(InputManager::Instance().IsJustPressed("MoveLeft")); // PostUpdate() clears just pressed
+    EXPECT_FALSE(InputManager::Instance().IsKeyJustPressed("MoveLeft")); // PostUpdate() clears just pressed
 }
 
 TEST_F(InputManagerTest, KeyJustPressedDetected)
@@ -85,10 +85,10 @@ TEST_F(InputManagerTest, KeyJustPressedDetected)
     event.key.code = sf::Keyboard::D;
 
     InputManager::Instance().Update(event);
-    EXPECT_TRUE(InputManager::Instance().IsJustPressed("MoveRight"));
+    EXPECT_TRUE(InputManager::Instance().IsKeyJustPressed("MoveRight"));
 
     InputManager::Instance().PostUpdate();
-    EXPECT_FALSE(InputManager::Instance().IsJustPressed("MoveRight")); // Only true on the first frame
+    EXPECT_FALSE(InputManager::Instance().IsKeyJustPressed("MoveRight")); // Only true on the first frame
 }
 
 TEST_F(InputManagerTest, KeyReleasedState)
@@ -104,7 +104,7 @@ TEST_F(InputManagerTest, KeyReleasedState)
     InputManager::Instance().Update(release);
 
     EXPECT_FALSE(InputManager::Instance().IsKeyPressed("MoveRight"));
-    EXPECT_FALSE(InputManager::Instance().IsJustPressed("MoveRight"));
+    EXPECT_FALSE(InputManager::Instance().IsKeyJustPressed("MoveRight"));
 }
 
 TEST_F(InputManagerTest, UnboundActionReturnsUnknownKey)


### PR DESCRIPTION
Added support for skipping SplashScene with 'enter', 'esc', or 'space'.

Changed how events are handled, previously Application would handle escape, and events were ignored per scene. Now scenes handle events relevant to them.