### PR TITLE
V1.2.5 UI arrow cleanup

### DIFF
--- a/src/core/common/UIPresets.h
+++ b/src/core/common/UIPresets.h
@@ -209,6 +209,9 @@ const sf::Color TOAST_DEFAULT_COLOR(102, 255, 102);
 // Generic Arrow uses:
 // ============================================================================
 
+/// @brief Default fixed pixel size for game to display Arrow.
+constexpr float DEFAULT_ARROW_SIZE_PIXEL = 64.f;
+
 /// @brief Default relative space from left boundary for an Arrow, 5%.
 constexpr float DEFAULT_ARROW_LEFT_CENTER_PERCENT = .05f;
 

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -342,23 +342,27 @@ void SettingsScene::CreateArrows(SettingsPage page)
     const auto winSize = WindowManager::Instance().GetWindow().getSize();
     const float centerY = winSize.y / 2.f;
 
+    const sf::Vector2f arrowSize = {DEFAULT_ARROW_SIZE_PIXEL, DEFAULT_ARROW_SIZE_PIXEL};
+
     if (page == SettingsPage::Audio || page == SettingsPage::KeyBindings)
     {
         // LEFT ARROW
-        const float arrow_x = scaleMgr.ScaledReferenceX(DEFAULT_ARROW_LEFT_CENTER_PERCENT);
-        auto leftArrow = UIFactory::Instance().CreateArrow(arrow_x, centerY, ArrowDirection::Left,
-                                                           [this, page]()
-                                                           {
-                                                               if (page == SettingsPage::KeyBindings)
-                                                               {
-                                                                   SwitchToPage(SettingsPage::Audio);
-                                                               }
+        const sf::Vector2f pos = {scaleMgr.ScaledReferenceX(DEFAULT_ARROW_LEFT_CENTER_PERCENT), centerY};
 
-                                                               else if (page == SettingsPage::Audio)
-                                                               {
-                                                                   SwitchToPage(SettingsPage::Video);
-                                                               }
-                                                           });
+        auto leftArrow =
+            UIFactory::Instance().CreateArrow(pos, arrowSize, UIAssets::UIArrowTextureKey, ArrowDirection::Left,
+                                              [this, page]()
+                                              {
+                                                  if (page == SettingsPage::KeyBindings)
+                                                  {
+                                                      SwitchToPage(SettingsPage::Audio);
+                                                  }
+
+                                                  else if (page == SettingsPage::Audio)
+                                                  {
+                                                      SwitchToPage(SettingsPage::Video);
+                                                  }
+                                              });
 
         UIManager::Instance().AddElement(leftArrow);
     }
@@ -366,20 +370,22 @@ void SettingsScene::CreateArrows(SettingsPage page)
     if (page == SettingsPage::Audio || page == SettingsPage::Video)
     {
         // RIGHT ARROW
-        const float arrow_x = scaleMgr.ScaledReferenceX(DEFAULT_ARROW_RIGHT_CENTER_PERCENT);
-        auto rightArrow = UIFactory::Instance().CreateArrow(arrow_x, centerY, ArrowDirection::Right,
-                                                            [this, page]()
-                                                            {
-                                                                if (page == SettingsPage::Audio)
-                                                                {
-                                                                    SwitchToPage(SettingsPage::KeyBindings);
-                                                                }
+        const sf::Vector2f pos = {scaleMgr.ScaledReferenceX(DEFAULT_ARROW_RIGHT_CENTER_PERCENT), centerY};
 
-                                                                else if (page == SettingsPage::Video)
-                                                                {
-                                                                    SwitchToPage(SettingsPage::Audio);
-                                                                }
-                                                            });
+        auto rightArrow =
+            UIFactory::Instance().CreateArrow(pos, arrowSize, UIAssets::UIArrowTextureKey, ArrowDirection::Right,
+                                              [this, page]()
+                                              {
+                                                  if (page == SettingsPage::Audio)
+                                                  {
+                                                      SwitchToPage(SettingsPage::KeyBindings);
+                                                  }
+
+                                                  else if (page == SettingsPage::Video)
+                                                  {
+                                                      SwitchToPage(SettingsPage::Audio);
+                                                  }
+                                              });
 
         UIManager::Instance().AddElement(rightArrow);
     }

--- a/src/core/ui/UIArrow.cpp
+++ b/src/core/ui/UIArrow.cpp
@@ -13,6 +13,7 @@
 #include "AssetManager.h"
 #include "Assets.h"
 #include "ResolutionScaleManager.h"
+#include <cmath>
 
 namespace
 {
@@ -30,16 +31,21 @@ constexpr float MAX_SCALE = 1.5f;
 
 /// @brief Base scale for this UIArrow.
 constexpr float BASE_SCALE = 1.0f;
+
+/// @brief Frequency in oscillations per second
+constexpr float PULSE_SPEED = 4.0f;
+
+/// @brief How much bigger/smaller than base
+constexpr float PULSE_AMPLITUDE = 0.5f;
 } // namespace
 
 /// @brief Constructor for the UIArrow.
 /// @param position Position to emplace.
+/// @param size Size to initialize with.
 /// @param direction Direction to face.
-UIArrow::UIArrow(const sf::Vector2f &position, ArrowDirection direction)
-    : m_direction(direction), m_position(position), m_size(64.f, 64.f)
+UIArrow::UIArrow(const sf::Vector2f &position, const sf::Vector2f &size, ArrowDirection direction)
+    : m_direction(direction), m_position(position), m_size(size)
 {
-    LoadTexture();
-    UpdateSprite();
 }
 
 /// @brief Performs internal state management during a single frame.
@@ -49,27 +55,43 @@ UIArrow::UIArrow(const sf::Vector2f &position, ArrowDirection direction)
 /// @param dt delta time
 void UIArrow::Update(const sf::Vector2i &mousePos, bool isMousePressed, bool isMouseJustPressed, float dt)
 {
-    m_hovered = m_sprite.getGlobalBounds().contains(static_cast<sf::Vector2f>(mousePos));
+    m_hovered = Contains(mousePos);
 
     if (m_opacity < MAX_OPACITY)
     {
-        m_opacity = std::min(MAX_OPACITY, m_opacity + FADE_SPEED * 0.016f);
+        m_opacity = std::min(MAX_OPACITY, m_opacity + FADE_SPEED * dt);
     }
 
-    float targetScale = m_hovered ? MAX_SCALE : BASE_SCALE;
-
-    if (m_scale < targetScale)
+    if (!m_hovered)
     {
-        m_scale = std::min(targetScale, m_scale + SCALE_SPEED * 0.016f);
+        m_animationTime += dt;
+
+        float pulse = std::sin(m_animationTime * PULSE_SPEED);
+        float dynamicScale = BASE_SCALE + PULSE_AMPLITUDE * pulse;
+
+        m_sprite.setScale(m_baseScale.x * dynamicScale, m_baseScale.y * dynamicScale);
     }
 
-    else if (m_scale > targetScale)
+    else
     {
-        m_scale = std::max(targetScale, m_scale - SCALE_SPEED * 0.016f);
+        // Smoothly return to BASE_SCALE multiplier
+        float targetScale = BASE_SCALE;
+        float delta = SCALE_SPEED * dt;
+
+        if (m_scale < targetScale)
+        {
+            m_scale = std::min(targetScale, m_scale + delta);
+        }
+
+        else if (m_scale > targetScale)
+        {
+            m_scale = std::max(targetScale, m_scale - delta);
+        }
+
+        m_sprite.setScale(m_baseScale.x * m_scale, m_baseScale.y * m_scale);
     }
 
     m_sprite.setColor(sf::Color(255, 255, 255, static_cast<sf::Uint8>(m_opacity)));
-    m_sprite.setScale(m_scale, m_scale);
 
     if (m_hovered && isMouseJustPressed)
     {
@@ -77,32 +99,48 @@ void UIArrow::Update(const sf::Vector2i &mousePos, bool isMousePressed, bool isM
     }
 }
 
-/// @brief Determines if the point is bound in the texture.
+/// @brief Determines if the point is bound in the texture. Using a more complex algorithm for a per-pixel computation.
 /// @param point Point to compair against us.
 /// @return true / false
 bool UIArrow::Contains(const sf::Vector2i &point) const
 {
-    if (!m_texture)
+    if (!m_sprite.getTexture())
     {
         return false;
     }
 
-    // Convert from screen coordinates to local sprite coordinates
+    // Step 1: Check bounding box
+    if (!m_sprite.getGlobalBounds().contains(static_cast<sf::Vector2f>(point)))
+    {
+        return false;
+    }
+
+    // Step 2: Convert to local coordinates
     sf::Vector2f local = m_sprite.getInverseTransform().transformPoint(static_cast<sf::Vector2f>(point));
 
-    // Ensure the point is within the texture bounds
-    const sf::IntRect texRect(0, 0, m_texture->getSize().x, m_texture->getSize().y);
+    const sf::Texture *tex = m_sprite.getTexture();
 
-    if (!texRect.contains(static_cast<sf::Vector2i>(local)))
+    if (!tex)
     {
         return false;
     }
 
-    // Get the pixel data
-    const sf::Image &image = m_texture->copyToImage();
-    sf::Color pixel = image.getPixel(static_cast<unsigned>(local.x), static_cast<unsigned>(local.y));
+    // Step 3: Get texture image
+    const sf::Image &image = tex->copyToImage();
 
-    return pixel.a > 32; // Consider hover only if mostly opaque
+    // Step 4: Convert to pixel coordinates in image space
+    unsigned int x = static_cast<unsigned int>(local.x);
+    unsigned int y = static_cast<unsigned int>(local.y);
+
+    if (x >= image.getSize().x || y >= image.getSize().y)
+    {
+        return false;
+    }
+
+    // Step 5: Check alpha
+    const sf::Color pixel = image.getPixel(x, y);
+
+    return pixel.a > 32; // Only consider "solid" pixels as interactive
 }
 
 /// @brief Sets the position for this UI Arrow.
@@ -120,11 +158,27 @@ sf::Vector2f UIArrow::GetPosition() const
     return m_position;
 }
 
+/// @brief Sets the internal sprite image for this UIArrow.
+/// @param texture Path to the texture asset.
+void UIArrow::SetTextureSkin(const std::string &texture)
+{
+    m_texture = texture;
+
+    auto tex = AssetManager::Instance().GetTexture(texture);
+
+    if (tex)
+    {
+        m_sprite.setTexture(*tex, true);
+        SetDirection(m_direction);
+    }
+}
+
 /// @brief Sets the size for this UIArrow.
 /// @param size new m_size.
 void UIArrow::SetSize(const sf::Vector2f &size)
 {
-    m_size = size; // unused since texture controls sizing, but kept for API consistency
+    m_size = size;
+    UpdateSprite();
 }
 
 /// @brief Returns the size for this UIArrow.
@@ -156,39 +210,45 @@ void UIArrow::draw(sf::RenderTarget &target, sf::RenderStates states) const
     target.draw(m_sprite, states);
 }
 
-/// @brief Load the texture into usable sprite for this UIArrow.
-void UIArrow::LoadTexture()
+/// @brief Sets the internal direction the arrow texture should face.
+/// @param dir new m_direction.
+void UIArrow::SetDirection(ArrowDirection dir)
 {
-    // NOTE: this is temporary hardcoded to always just use the namespace key/value for uiarrow texture.
-    // we may at the future wish to load based on parameter.
-    const std::string textureName = UIAssets::UIArrowTextureKey;
-    AssetManager::Instance().LoadTexture(textureName, UIAssets::Textures.at(textureName));
-    m_texture = AssetManager::Instance().GetTexture(textureName);
-    m_sprite.setTexture(*m_texture);
+    if (m_sprite.getTexture())
+    {
+        // Rotate based on direction
+        switch (m_direction)
+        {
+            case ArrowDirection::Left:
+                m_sprite.setRotation(0.f);
+                break;
+            case ArrowDirection::Right:
+                m_sprite.setRotation(180.f);
+                break;
+            case ArrowDirection::Up:
+                m_sprite.setRotation(90.f);
+                break;
+            case ArrowDirection::Down:
+                m_sprite.setRotation(270.f);
+                break;
+        }
+
+        UpdateSprite();
+    }
 }
 
 /// @brief Correct the texture sprites position and orientation.
 void UIArrow::UpdateSprite()
 {
-    m_sprite.setPosition(m_position);
-    m_sprite.setOrigin(m_sprite.getLocalBounds().width / 2.f, m_sprite.getLocalBounds().height / 2.f);
-
-    // Rotate based on direction
-    switch (m_direction)
+    if (m_sprite.getTexture())
     {
-        case ArrowDirection::Left:
-            m_sprite.setRotation(0.f);
-            break;
-        case ArrowDirection::Right:
-            m_sprite.setRotation(180.f);
-            break;
-        case ArrowDirection::Up:
-            m_sprite.setRotation(90.f);
-            break;
-        case ArrowDirection::Down:
-            m_sprite.setRotation(270.f);
-            break;
-    }
+        const sf::Vector2u texSize = m_sprite.getTexture()->getSize();
 
-    m_sprite.setScale(m_scale, m_scale);
+        m_baseScale.x = m_size.x / static_cast<float>(texSize.x);
+        m_baseScale.y = m_size.y / static_cast<float>(texSize.y);
+
+        m_sprite.setPosition(m_position);
+        m_sprite.setOrigin(m_sprite.getLocalBounds().width / 2.f, m_sprite.getLocalBounds().height / 2.f);
+        m_sprite.setScale(m_baseScale.x, m_baseScale.y);
+    }
 }

--- a/src/core/ui/UIArrow.h
+++ b/src/core/ui/UIArrow.h
@@ -37,7 +37,7 @@ enum class ArrowDirection
 class UIArrow : public UIElement
 {
   public:
-    UIArrow(const sf::Vector2f &position, ArrowDirection direction);
+    UIArrow(const sf::Vector2f &position, const sf::Vector2f &size, ArrowDirection direction);
     ~UIArrow() override = default;
 
     // Disable copy
@@ -54,28 +54,34 @@ class UIArrow : public UIElement
     void SetPosition(const sf::Vector2f &position) override;
     sf::Vector2f GetPosition() const override;
 
+    void SetTextureSkin(const std::string &texture);
+
     void SetSize(const sf::Vector2f &size) override;
     sf::Vector2f GetSize() const override;
 
     void SetOnClick(std::function<void()> callback);
+
     const ArrowDirection GetDirection() const;
 
   protected:
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 
   private:
-    void LoadTexture();
+    void SetDirection(ArrowDirection dir);
     void UpdateSprite();
 
   private:
     ArrowDirection m_direction;
     sf::Sprite m_sprite;
-    sf::Texture *m_texture = nullptr;
+    sf::String m_texture;
     sf::Vector2f m_position;
     sf::Vector2f m_size;
+    sf::Vector2f m_baseScale;
 
     float m_opacity = 0.f;
     float m_scale = 1.0f;
+    float m_animationTime = 0.f;
+
     bool m_hovered = false;
     bool m_pressedLastFrame = false;
 

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -125,16 +125,23 @@ std::shared_ptr<UISlider> UIFactory::CreateSlider(const std::string &label, cons
 }
 
 /// @brief Creates a UI Arrow element, given the custom input parameters.
-/// @param x X coordinate for position to be set.
-/// @param y Y coordinate for position to be set.
+/// @param position Position to emplace.
+/// @param size Size to initialize with.
+/// @param texture Loadable texture path.
 /// @param direction Arrow direction L, R, U, D.
 /// @param onClick Pointer to callback function, when clicked.
-/// @return safe pointer to a UIArrow.
-std::shared_ptr<UIArrow> UIFactory::CreateArrow(float x, float y, ArrowDirection direction,
+/// @return Safe pointer to a UIArrow.
+std::shared_ptr<UIArrow> UIFactory::CreateArrow(const sf::Vector2f &position, const sf::Vector2f &size,
+                                                const std::string &texture, ArrowDirection direction,
                                                 std::function<void()> onClick)
 {
-    auto arrow = std::make_shared<UIArrow>(sf::Vector2f{x, y}, direction);
+    sf::Vector2f scaledSize(ResolutionScaleManager::Instance().ScaleX(size.x),
+                            ResolutionScaleManager::Instance().ScaleY(size.y));
+
+    auto arrow = std::make_shared<UIArrow>(position, scaledSize, direction);
     arrow->SetOnClick(onClick);
+    arrow->SetTextureSkin(texture);
+    arrow->SetSize(scaledSize);
 
     return arrow;
 }

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -52,7 +52,9 @@ class UIFactory
                                            const sf::Vector2f &size, float minValue, float maxValue, float initialValue,
                                            std::function<void(float)> onChange);
 
-    std::shared_ptr<UIArrow> CreateArrow(float x, float y, ArrowDirection direction, std::function<void()> onClick);
+    std::shared_ptr<UIArrow> CreateArrow(const sf::Vector2f &position, const sf::Vector2f &size,
+                                         const std::string &texture, ArrowDirection direction,
+                                         std::function<void()> onClick);
 
     std::shared_ptr<UIGroupBox> CreateGroupBox(const std::string &title, const sf::Vector2f &relativePos,
                                                const sf::Vector2f &relativeSize);

--- a/src/core/ui/UISkinnableButton.cpp
+++ b/src/core/ui/UISkinnableButton.cpp
@@ -18,10 +18,9 @@
 /// @brief Constructs a UISkinnableButton.
 /// @param position Sets internal position.
 /// @param size Sets internal size.
-UISkinnableButton::UISkinnableButton(const sf::Vector2f &position, const sf::Vector2f &size) : m_size(size)
+UISkinnableButton::UISkinnableButton(const sf::Vector2f &position, const sf::Vector2f &size)
+    : m_size(size), m_position(position)
 {
-    SetPosition(position);
-    SetSize(size);
 }
 
 /// @brief Sets the internal idle and hover textures for this UISkinnableButton.

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 2
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 4
+#define CT_VERSION_PATCH 5
 
 /// @brief String representation for Chaos Theory version.
-#define CT_VERSION_STRING "1.2.4"
+#define CT_VERSION_STRING "1.2.5"

--- a/test/AudioManagerTest.cpp
+++ b/test/AudioManagerTest.cpp
@@ -86,13 +86,13 @@ TEST_F(AudioManagerTest, SetVolumeSynchronizesWithSettings)
 
 TEST_F(AudioManagerTest, PlayMusicSetsState)
 {
-    AudioManager::Instance().PlayMusic(m_settings->m_audioDirectory + "Default.wav", false);
+    AudioManager::Instance().PlayMusic(m_settings->m_audioDirectory + "RootMenu.wav", false);
     EXPECT_TRUE(AudioManager::Instance().IsMusicPlaying());
 }
 
 TEST_F(AudioManagerTest, SwitchTrackUpdatesState)
 {
-    std::string track = m_settings->m_audioDirectory + "Default.wav";
+    std::string track = m_settings->m_audioDirectory + "IntroClip.wav";
 
     AudioManager::Instance().PlayMusic(track);
     EXPECT_TRUE(AudioManager::Instance().IsMusicPlaying());

--- a/test/UIArrowTest.cpp
+++ b/test/UIArrowTest.cpp
@@ -45,7 +45,7 @@ class UIArrowTest : public ::testing::Test
 
 TEST_F(UIArrowTest, CreationSetsCorrectPositionAndDirection)
 {
-    UIArrow arrow({100.f, 200.f}, ArrowDirection::Left);
+    UIArrow arrow({100.f, 200.f}, {64.f, 64.f}, ArrowDirection::Left);
 
     EXPECT_EQ(arrow.GetPosition(), sf::Vector2f(100.f, 200.f));
     EXPECT_EQ(arrow.GetDirection(), ArrowDirection::Left);
@@ -53,14 +53,14 @@ TEST_F(UIArrowTest, CreationSetsCorrectPositionAndDirection)
 
 TEST_F(UIArrowTest, SetPositionUpdatesCorrectly)
 {
-    UIArrow arrow({100.f, 200.f}, ArrowDirection::Right);
+    UIArrow arrow({100.f, 200.f}, {64.f, 64.f}, ArrowDirection::Right);
     arrow.SetPosition({300.f, 300.f});
-    EXPECT_TRUE(arrow.Contains({310, 310}));
+    EXPECT_EQ(arrow.GetPosition(), sf::Vector2f(300.f, 300.f));
 }
 
 TEST_F(UIArrowTest, SetSizeUpdatesCorrectly)
 {
-    UIArrow arrow({100.f, 200.f}, ArrowDirection::Right);
+    UIArrow arrow({100.f, 200.f}, {64.f, 64.f}, ArrowDirection::Right);
     arrow.SetSize({128.f, 128.f});
     EXPECT_GT(arrow.GetSize().x, 64.f);
     EXPECT_GT(arrow.GetSize().y, 64.f);


### PR DESCRIPTION
patched: Clean up UIArrow interface for consistency.
	- UIArrow factory now requires a texture path.
	- UIArrow now properly adjusts with resolution scaling.
	- UIArrow now Grows and shrinks while NOT hovered, and holds size while hovered.
	- Fixed 2 unit tests that broke with the update of patch 1.2.4
	- Updated UIArrow Unit test: SetPosition.
	- Corrected UISkinnableButton constructor list to set size and position with internals instead of calling SetPosition, and SetSize explicitely.