### PR TITLE
V1.2.6 text label scheme

### DIFF
--- a/src/core/common/UIPresets.h
+++ b/src/core/common/UIPresets.h
@@ -15,32 +15,44 @@
 #include <string>
 
 // ============================================================================
-// Titles:
+// Text Labels:
 // ============================================================================
 
-/// @brief Default Title string color.
-const sf::Color DEFAULT_TITLE_COLOR = sf::Color(102, 255, 102);
+/// @brief Lime green Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_LIME_GREEN = sf::Color(102, 255, 102);
 
-/// @brief Deep muted green outline color.
-const sf::Color TITLE_OUTLINE_SOFT_SHADOW = sf::Color(30, 60, 30);
+/// @brief Deep dark green Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_MUTE_GREEN = sf::Color(30, 60, 30);
 
-/// @brief Neutral grey outline color.
-const sf::Color TITLE_OUTLINE_COOL_GREY = sf::Color(50, 50, 50);
+/// @brief Neutral grey Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_COOL_GREY = sf::Color(50, 50, 50);
 
-/// @brief Favored default title outline color. Deep violet.
-const sf::Color TITLE_OUTLINE_PURPLE_TINT = sf::Color(90, 0, 130);
+/// @brief Color code for Cougar Grey Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_COUGAR_GREY = sf::Color(94, 106, 113);
 
-/// @brief Minty teal title outline color.
-const sf::Color TITLE_OUTLINE_TEAL_GLOW = sf::Color(0, 180, 150);
+/// @brief Color code for Cougar Crimson Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_COUGAR_CRIMSON = sf::Color(152, 30, 50);
 
-/// @brief Default Title border padding.
-const float DEFAULT_TITLE_BORDER_THICKNESS = 2.f;
+/// @brief Blue Steel Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_BLUE_STEEL = sf::Color(23, 157, 235);
 
-/// @brief Default Title font size.
-constexpr unsigned int DEFAULT_TITLE_FONT_SIZE = 48;
+/// @brief Deep Violet Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_PURPLE_TINT = sf::Color(90, 0, 130);
 
-/// @brief Default relative positioning for Title string.
-constexpr float DEFAULT_TITLE_HEIGHT_PERCENT = .1f;
+/// @brief Metallic Gold Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_METALLIC_GOLD = sf::Color(255, 215, 0);
+
+/// @brief Minty Teal Text Label string color.
+const sf::Color TEXT_LABEL_COLOR_TEAL_MINT = sf::Color(0, 180, 150);
+
+/// @brief Default Text Label string border padding.
+const float DEFAULT_TEXT_LABEL_BORDER_THICKNESS = 2.f;
+
+/// @brief Default Text Label Title string font size.
+constexpr unsigned int DEFAULT_TEXT_LABEL_TITLE_FONT_SIZE = 48;
+
+/// @brief Default relative positioning for Text Label Title string.
+constexpr float DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT = .1f;
 
 // ============================================================================
 // Generic Button uses:

--- a/src/core/scenes/MainMenuScene.cpp
+++ b/src/core/scenes/MainMenuScene.cpp
@@ -241,11 +241,12 @@ void MainMenuScene::CreateTitleText()
     auto &scaleMgr = ResolutionScaleManager::Instance();
 
     const std::string titleText = DEFAULT_TITLE_STR;
-    const unsigned int fontSize = scaleMgr.ScaleFont(DEFAULT_TITLE_FONT_SIZE);
+    const unsigned int fontSize = scaleMgr.ScaleFont(DEFAULT_TEXT_LABEL_TITLE_FONT_SIZE);
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
-                                    scaleMgr.ScaledReferenceY(DEFAULT_TITLE_HEIGHT_PERCENT)};
+                                    scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
+    m_titleLabel =
+        UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true, UITextLabelScheme::DefaultScheme);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }

--- a/src/core/scenes/SandBoxScene.cpp
+++ b/src/core/scenes/SandBoxScene.cpp
@@ -196,7 +196,8 @@ void SandBoxScene::CreateTitleText()
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
                                     scaleMgr.ScaledReferenceY(0.08f)};
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(title, centerPos, fontSize, true);
+    m_titleLabel =
+        UIFactory::Instance().CreateTextLabel(title, centerPos, fontSize, true, UITextLabelScheme::MintyHerbScheme);
     UIManager::Instance().AddElement(m_titleLabel);
 }
 

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -312,11 +312,12 @@ void SettingsScene::CreateTitleText()
     auto &scaleMgr = ResolutionScaleManager::Instance();
 
     const std::string titleText = DEFAULT_SETTINGS_STR;
-    const unsigned int fontSize = scaleMgr.ScaleFont(DEFAULT_TITLE_FONT_SIZE);
+    const unsigned int fontSize = scaleMgr.ScaleFont(DEFAULT_TEXT_LABEL_TITLE_FONT_SIZE);
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
-                                    scaleMgr.ScaledReferenceY(DEFAULT_TITLE_HEIGHT_PERCENT)};
+                                    scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
+    m_titleLabel =
+        UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true, UITextLabelScheme::DefaultScheme);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -74,6 +74,15 @@ std::shared_ptr<UISelectableButton> UIFactory::CreateSelectableButton(const sf::
     return btn;
 }
 
+/// @brief Generates a SkinnableButton ui element.
+/// @param pos Position to set button at.
+/// @param size Size to initialize button with.
+/// @param label Text to initialize button with.
+/// @param idle Path to Idle texture to be used for SkinnableButton
+/// @param hover Path to Hover texture to be used for SkinnableButton
+/// @param scheme Enum field representing the scheme for Button text layouts.
+/// @param onClick Pointer to callback function, when clicked.
+/// @return Smart pointer to a UISkinnableButton.
 std::shared_ptr<UISkinnableButton> UIFactory::CreateSkinnableButton(const sf::Vector2f &pos, const sf::Vector2f &size,
                                                                     const std::string &label, const std::string &idle,
                                                                     const std::string &hover,
@@ -177,24 +186,24 @@ std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, 
 /// @brief Creates a UI UITextLabel element, given the custom input parameters.
 /// @param text String representation for the element.
 /// @param position Position for text label.
-/// @param baseFontSize Font size for the text label.
+/// @param fontSize Size of the font for the Text.
 /// @param centerOrigin Used for centering the string contents around the position during construction.
-/// @return safe pointer to a UITextLabel.
+/// @param scheme Enum field representing the type of shceme.
+/// @return Safe pointer to a UITextLabel.
 std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text, const sf::Vector2f &position,
-                                                        unsigned int baseFontSize, bool centerOrigin)
+                                                        unsigned int fontSize, bool centerOrigin,
+                                                        UITextLabelScheme scheme)
 {
-    auto scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(baseFontSize);
-    const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TITLE_BORDER_THICKNESS);
+    const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TEXT_LABEL_BORDER_THICKNESS);
 
-    auto label =
-        std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont("Default"), scaledFontSize, position);
+    auto label = std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont("Default"), fontSize, position);
 
     if (!centerOrigin)
+    {
         label->SetPosition(position); // no auto-centering
+    }
 
-    // TODO - implement a color scheme enum like the UISkinnableButton.
-    label->SetColor(DEFAULT_TITLE_COLOR);
-    label->SetOutline(scaledOutline, TITLE_OUTLINE_PURPLE_TINT);
+    ApplyTextLabelStyle(*label, scheme, scaledOutline);
 
     return label;
 }
@@ -219,8 +228,8 @@ std::shared_ptr<UIToastMessage> UIFactory::CreateToastMessage(const std::string 
 }
 
 /// @brief A private helper method to utilize color themes for a SkinnableButton combo.
-/// @param button reference to the button to be changed.
-/// @param scheme enum field representing  the type of theme.
+/// @param button Reference to the button to be changed.
+/// @param scheme Enum field representing  the type of scheme.
 void UIFactory::ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButtonColorScheme scheme)
 {
     switch (scheme)
@@ -235,6 +244,46 @@ void UIFactory::ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButto
 
         case UIButtonColorScheme::Red:
             button.SetTextStyle(TEX_BTN_RED_LABEL_TEXT_COLOR, TEX_BTN_RED_TEXT_OUTLINE_COLOR, 2.0f);
+            break;
+    }
+}
+
+/// @brief A private helper method to utilize color themes for a TextLabel string combo.
+/// @param label Reference to the UITextLabel to be changed.
+/// @param scheme Enum field representing the type of shceme.
+void UIFactory::ApplyTextLabelStyle(UITextLabel &label, UITextLabelScheme scheme, const float labelBorderSize)
+{
+    switch (scheme)
+    {
+        case UITextLabelScheme::DefaultScheme:
+        default:
+            // Default scheme is LimeGreen with Purple contrast border.
+            label.SetColor(TEXT_LABEL_COLOR_LIME_GREEN);
+            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_PURPLE_TINT);
+            break;
+
+        case UITextLabelScheme::CougarScheme:
+            // CougarScheme scheme is Crimson with Grey contrast border.
+            label.SetColor(TEXT_LABEL_COLOR_COUGAR_CRIMSON);
+            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_COUGAR_GREY);
+            break;
+
+        case UITextLabelScheme::HuskyScheme:
+            // HuskyScheme scheme is PurpleTint with MetallicGold contrast border.
+            label.SetColor(TEXT_LABEL_COLOR_PURPLE_TINT);
+            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_METALLIC_GOLD);
+            break;
+
+        case UITextLabelScheme::BlueSteelScheme:
+            // BlueSteelScheme scheme is BlueSteel with CoolGrey contrast border.
+            label.SetColor(TEXT_LABEL_COLOR_BLUE_STEEL);
+            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_COOL_GREY);
+            break;
+
+        case UITextLabelScheme::MintyHerbScheme:
+            // MintyHerbScheme scheme is TealMint with Dark Green contrast border.
+            label.SetColor(TEXT_LABEL_COLOR_TEAL_MINT);
+            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_MUTE_GREEN);
             break;
     }
 }

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -60,13 +60,15 @@ class UIFactory
                                                const sf::Vector2f &relativeSize);
 
     std::shared_ptr<UITextLabel> CreateTextLabel(const std::string &text, const sf::Vector2f &position,
-                                                 unsigned int baseFontSize, bool centerOrigin);
+                                                 unsigned int baseFontSize, bool centerOrigin,
+                                                 UITextLabelScheme scheme);
 
     std::shared_ptr<UIToastMessage> CreateToastMessage(const std::string &text, const sf::Vector2f &position,
                                                        float duration);
 
   private:
     void ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButtonColorScheme scheme);
+    void ApplyTextLabelStyle(UITextLabel &label, UITextLabelScheme scheme, const float labelBorderSize);
 
   private:
     UIFactory() = default;

--- a/src/core/ui/UITextLabel.h
+++ b/src/core/ui/UITextLabel.h
@@ -16,6 +16,16 @@
 #include <SFML/Graphics.hpp>
 #include <string>
 
+/// @brief Enumeration field which corresponds to a type of supported UITextLabel color scheme combination.
+enum class UITextLabelScheme
+{
+    DefaultScheme,
+    CougarScheme,
+    HuskyScheme,
+    BlueSteelScheme,
+    MintyHerbScheme
+};
+
 // ============================================================================
 //  Class       : UITextLabel
 //  Purpose     : Manages this UITextLabel logic at the ui level.

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 2
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 5
+#define CT_VERSION_PATCH 6
 
 /// @brief String representation for Chaos Theory version.
-#define CT_VERSION_STRING "1.2.5"
+#define CT_VERSION_STRING "1.2.6"


### PR DESCRIPTION
patched: Add support for Text Label preset color schemes
		- Updated UIFactory to support a helper method for premade Text Label color schemes.
		- Added some color constants to UIPresets.h
		- Defined UITextLabelScheme enum in UITextLabel.