### PR TITLE
V1.2.7 UI text label reusability

### DIFF
--- a/src/core/common/UIPresets.h
+++ b/src/core/common/UIPresets.h
@@ -115,6 +115,12 @@ constexpr float BUTTON_DEFAULT_SCALE_SIZE = 1.05f;
 /// @brief Default button font size.
 constexpr unsigned int BUTTON_DEFAULT_FONT_SIZE = 24;
 
+/// @brief Default skinnable button font size.
+constexpr unsigned int SKINNABLE_BUTTON_DEFAULT_FONT_SIZE = 18;
+
+/// @brief Default selectable button font size.
+constexpr unsigned int SELECTABLE_BUTTON_DEFAULT_FONT_SIZE = 18;
+
 /// @brief Generic button width in pixels.
 constexpr float BASE_BUTTON_WIDTH_PIXEL = 180.f;
 

--- a/src/core/common/UIPresets.h
+++ b/src/core/common/UIPresets.h
@@ -155,6 +155,12 @@ constexpr float BASE_SLIDER_HEIGHT_PIXEL = 20.f;
 /// @brief Generic slider spacing in pixels.
 constexpr float BASE_SLIDER_SPACING_PIXEL = 50.f;
 
+/// @brief Generic slider Y offset for the UITextLabel title.
+constexpr float BASE_SLIDER_OFFSET_Y = 24.f;
+
+/// @brief Generic slider UITextLabel expected font size.
+constexpr unsigned int BASE_SLIDER_TITLE_FONT_SIZE = 14;
+
 /// @brief Generic slider spacing in relative screen sizing, 5%.
 constexpr float BASE_SLIDER_SPACING_PERCENT = .05f;
 

--- a/src/core/common/UIPresets.h
+++ b/src/core/common/UIPresets.h
@@ -182,7 +182,7 @@ const sf::Color BASE_SLIDER_FILL_COLOR = sf::Color(200, 200, 200);
 /// @brief Generic color for the background for default constructing.
 const sf::Color BASE_SLIDER_BACK_COLOR = sf::Color(100, 100, 100);
 
-/// @brief Generic color for the knob for default constructing.
+/// @brief Lime green color for the knob for default constructing.
 const sf::Color BASE_SLIDER_KNOB_COLOR = sf::Color(102, 255, 102);
 
 // ============================================================================
@@ -217,6 +217,9 @@ constexpr unsigned int BASE_GROUPBOX_FONT_SIZE = 24;
 // Generic Toast uses:
 // ============================================================================
 
+/// @brief General use default font size for the Toast message.
+constexpr unsigned int TOAST_DEFAULT_FONT_SIZE = 18;
+
 /// @brief General use default time for a toast message to expire.
 constexpr float TOAST_DEFAULT_DURATION = 2.f;
 
@@ -226,7 +229,7 @@ constexpr float TOAST_DEFAULT_FADE_DURATION = 1.f;
 /// @brief General use distance a toast message will travel while active.
 constexpr float TOAST_DEFAULT_DRIFT_PERCENTAGE = .05f;
 
-/// @brief General use default color for a toast message.
+/// @brief Lime green color for a toast message.
 const sf::Color TOAST_DEFAULT_COLOR(102, 255, 102);
 
 // ============================================================================

--- a/src/core/scenes/MainMenuScene.cpp
+++ b/src/core/scenes/MainMenuScene.cpp
@@ -245,8 +245,7 @@ void MainMenuScene::CreateTitleText()
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
                                     scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel =
-        UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true, UITextLabelScheme::DefaultScheme);
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }

--- a/src/core/scenes/MainMenuScene.cpp
+++ b/src/core/scenes/MainMenuScene.cpp
@@ -245,7 +245,7 @@ void MainMenuScene::CreateTitleText()
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
                                     scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -599,8 +599,8 @@ void SettingsScene::ShowToast(const std::string &message)
     const auto winSize = WindowManager::Instance().GetWindow().getSize();
     sf::Vector2f pos{winSize.x * BASE_FOOTER_WIDTH_75_PERCENT, winSize.y * BASE_FOOTER_HEIGHT_85_PERCENT};
 
-    auto toast = UIFactory::Instance().CreateToastMessage(message, pos, TOAST_DEFAULT_DURATION);
-    toast->SetColor(TOAST_DEFAULT_COLOR);
+    auto toast =
+        UIFactory::Instance().CreateToastMessage(message, pos, TOAST_DEFAULT_DURATION, TOAST_DEFAULT_FONT_SIZE);
     UIManager::Instance().AddElement(toast);
 }
 

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -316,7 +316,7 @@ void SettingsScene::CreateTitleText()
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
                                     scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }
@@ -468,8 +468,7 @@ void SettingsScene::CreateAudioControls()
     const sf::Vector2f relativeSize{0.5f, 0.5f};
 
     // Create a 50% screen width, 50% screen height UIGroupBox for UI elements as children.
-    auto groupBox =
-        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
+    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
 
     const float referenceSliderWidth = BASE_SLIDER_WIDTH_PERCENT; // 45% of reference width
     const float sliderHeight = scaleMgr.ScaleY(BASE_SLIDER_HEIGHT_PIXEL);
@@ -500,8 +499,7 @@ void SettingsScene::CreateResolutionControls()
     const sf::Vector2f relativeSize{0.25f, 0.40f};
 
     // Create the group box using the centralized UIFactory
-    auto groupBox =
-        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
+    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
     groupBox->SetEdgePadding(scaleMgr.ScaledReferenceY(.02f));
     groupBox->SetInternalPadding(scaleMgr.ScaledReferenceY(.15f * relativeSize.y));
 
@@ -548,8 +546,7 @@ void SettingsScene::CreateDifficultyControls()
     const sf::Vector2f relativeSize{0.25f, 0.40f};
 
     // Create the group box using the centralized UIFactory
-    auto groupBox =
-        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
+    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
     groupBox->SetEdgePadding(scaleMgr.ScaledReferenceY(.02f));
     groupBox->SetInternalPadding(scaleMgr.ScaledReferenceY(.15f * relativeSize.y));
 

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -316,8 +316,7 @@ void SettingsScene::CreateTitleText()
     const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
                                     scaleMgr.ScaledReferenceY(DEFAULT_TEXT_LABEL_TITLE_HEIGHT_PERCENT)};
 
-    m_titleLabel =
-        UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true, UITextLabelScheme::DefaultScheme);
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleText, centerPos, fontSize, true);
 
     UIManager::Instance().AddElement(m_titleLabel);
 }
@@ -469,7 +468,8 @@ void SettingsScene::CreateAudioControls()
     const sf::Vector2f relativeSize{0.5f, 0.5f};
 
     // Create a 50% screen width, 50% screen height UIGroupBox for UI elements as children.
-    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
+    auto groupBox =
+        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
 
     const float referenceSliderWidth = BASE_SLIDER_WIDTH_PERCENT; // 45% of reference width
     const float sliderHeight = scaleMgr.ScaleY(BASE_SLIDER_HEIGHT_PIXEL);
@@ -500,7 +500,8 @@ void SettingsScene::CreateResolutionControls()
     const sf::Vector2f relativeSize{0.25f, 0.40f};
 
     // Create the group box using the centralized UIFactory
-    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
+    auto groupBox =
+        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
     groupBox->SetEdgePadding(scaleMgr.ScaledReferenceY(.02f));
     groupBox->SetInternalPadding(scaleMgr.ScaledReferenceY(.15f * relativeSize.y));
 
@@ -547,7 +548,8 @@ void SettingsScene::CreateDifficultyControls()
     const sf::Vector2f relativeSize{0.25f, 0.40f};
 
     // Create the group box using the centralized UIFactory
-    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
+    auto groupBox =
+        UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize, UITextLabelScheme::BlueSteelScheme);
     groupBox->SetEdgePadding(scaleMgr.ScaledReferenceY(.02f));
     groupBox->SetInternalPadding(scaleMgr.ScaledReferenceY(.15f * relativeSize.y));
 

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -161,7 +161,7 @@ std::shared_ptr<UIArrow> UIFactory::CreateArrow(const sf::Vector2f &position, co
 /// @param relativeSize Screen relative size to occupy.
 /// @return safe pointer to a UIGroupBox.
 std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, const sf::Vector2f &relativePosition,
-                                                      const sf::Vector2f &relativeSize)
+                                                      const sf::Vector2f &relativeSize, UITextLabelScheme scheme)
 {
     auto &scaleMgr = ResolutionScaleManager::Instance();
 
@@ -173,8 +173,8 @@ std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, 
     const float edgePadding = scaleMgr.ScaledReferenceY(BASE_GROUPBOX_EDGE_PAD_RATIO);
 
     auto groupBox = std::make_shared<UIGroupBox>(scaledPos, scaledSize);
-    groupBox->SetTitle(title, *AssetManager::Instance().GetFont("Default"),
-                       scaleMgr.ScaleFont(BASE_GROUPBOX_FONT_SIZE));
+    groupBox->SetTitle(title, *AssetManager::Instance().GetFont("Default"), scaleMgr.ScaleFont(BASE_GROUPBOX_FONT_SIZE),
+                       scheme);
     groupBox->SetLayoutMode(LayoutMode::Vertical); // safe default state
     groupBox->SetCenterChildren(true);             // safe default state
     groupBox->SetInternalPadding(internalPadding);
@@ -203,7 +203,7 @@ std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text,
         label->SetPosition(position); // no auto-centering
     }
 
-    ApplyTextLabelStyle(*label, scheme, scaledOutline);
+    label->ApplyTextLabelStyle(scheme, scaledOutline);
 
     return label;
 }
@@ -244,46 +244,6 @@ void UIFactory::ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButto
 
         case UIButtonColorScheme::Red:
             button.SetTextStyle(TEX_BTN_RED_LABEL_TEXT_COLOR, TEX_BTN_RED_TEXT_OUTLINE_COLOR, 2.0f);
-            break;
-    }
-}
-
-/// @brief A private helper method to utilize color themes for a TextLabel string combo.
-/// @param label Reference to the UITextLabel to be changed.
-/// @param scheme Enum field representing the type of shceme.
-void UIFactory::ApplyTextLabelStyle(UITextLabel &label, UITextLabelScheme scheme, const float labelBorderSize)
-{
-    switch (scheme)
-    {
-        case UITextLabelScheme::DefaultScheme:
-        default:
-            // Default scheme is LimeGreen with Purple contrast border.
-            label.SetColor(TEXT_LABEL_COLOR_LIME_GREEN);
-            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_PURPLE_TINT);
-            break;
-
-        case UITextLabelScheme::CougarScheme:
-            // CougarScheme scheme is Crimson with Grey contrast border.
-            label.SetColor(TEXT_LABEL_COLOR_COUGAR_CRIMSON);
-            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_COUGAR_GREY);
-            break;
-
-        case UITextLabelScheme::HuskyScheme:
-            // HuskyScheme scheme is PurpleTint with MetallicGold contrast border.
-            label.SetColor(TEXT_LABEL_COLOR_PURPLE_TINT);
-            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_METALLIC_GOLD);
-            break;
-
-        case UITextLabelScheme::BlueSteelScheme:
-            // BlueSteelScheme scheme is BlueSteel with CoolGrey contrast border.
-            label.SetColor(TEXT_LABEL_COLOR_BLUE_STEEL);
-            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_COOL_GREY);
-            break;
-
-        case UITextLabelScheme::MintyHerbScheme:
-            // MintyHerbScheme scheme is TealMint with Dark Green contrast border.
-            label.SetColor(TEXT_LABEL_COLOR_TEAL_MINT);
-            label.SetOutline(labelBorderSize, TEXT_LABEL_COLOR_MUTE_GREEN);
             break;
     }
 }

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -210,17 +210,19 @@ std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text,
 /// @param text String representation for the toast message.
 /// @param position Position for the toast message.
 /// @param duration Duration for how long the toast message will exist.
+/// @param baseFontSize Font size to initialize with.
+/// @param centerOrigin Whether or not the center text around origin.
+/// @param scheme Enum field representing the type of shceme.
 /// @return safe pointer to a UIToastMessage.
 std::shared_ptr<UIToastMessage> UIFactory::CreateToastMessage(const std::string &text, const sf::Vector2f &position,
-                                                              float duration)
+                                                              float duration, unsigned int baseFontSize,
+                                                              bool centerOrigin, UITextLabelScheme scheme)
 {
-    const auto &font = *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey);
-    unsigned int fontSize = ResolutionScaleManager::Instance().ScaleFont(18);
-    sf::Color color = sf::Color::White;
-    bool centerOrigin = true;
+    const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TEXT_LABEL_BORDER_THICKNESS);
+    const unsigned int fontSize = ResolutionScaleManager::Instance().ScaleFont(baseFontSize);
 
-    auto toast = std::make_shared<UIToastMessage>(text, position, duration, font, fontSize, color, centerOrigin);
-    toast->SetSize({0.f, 0.f}); // still required by interface
+    auto toast = std::make_shared<UIToastMessage>(text, position, fontSize, duration, centerOrigin, scheme);
+    toast->ApplyStyle(scheme, scaledOutline);
 
     return toast;
 }

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<UIButton> UIFactory::CreateButton(const sf::Vector2f &position, 
 {
     sf::Vector2f scaledSize(ResolutionScaleManager::Instance().ScaleX(size.x),
                             ResolutionScaleManager::Instance().ScaleY(size.y));
-    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(18);
+    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(BUTTON_DEFAULT_FONT_SIZE);
 
     auto btn = std::make_shared<UIButton>(position, scaledSize);
 
@@ -62,7 +62,7 @@ std::shared_ptr<UISelectableButton> UIFactory::CreateSelectableButton(const sf::
 {
     sf::Vector2f scaledSize(ResolutionScaleManager::Instance().ScaleX(size.x),
                             ResolutionScaleManager::Instance().ScaleY(size.y));
-    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(18);
+    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(SELECTABLE_BUTTON_DEFAULT_FONT_SIZE);
 
     auto btn = std::make_shared<UISelectableButton>(position, scaledSize);
 
@@ -92,7 +92,7 @@ std::shared_ptr<UISkinnableButton> UIFactory::CreateSkinnableButton(const sf::Ve
 {
     sf::Vector2f scaledSize(ResolutionScaleManager::Instance().ScaleX(size.x),
                             ResolutionScaleManager::Instance().ScaleY(size.y));
-    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(18);
+    unsigned int scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(SKINNABLE_BUTTON_DEFAULT_FONT_SIZE);
 
     auto btn = std::make_shared<UISkinnableButton>(pos, scaledSize);
 

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -97,9 +97,8 @@ std::shared_ptr<UISkinnableButton> UIFactory::CreateSkinnableButton(const sf::Ve
 
     btn->SetText(label, *AssetManager::Instance().GetFont("Default"), scaledFontSize);
     btn->SetTextureSkins(idle, hover);
+    btn->ApplySkinnableButtonTextStyle(scheme);
     btn->SetCallback(onClick);
-
-    ApplySkinnableButtonTextStyle(*btn, scheme);
 
     return btn;
 }
@@ -225,25 +224,4 @@ std::shared_ptr<UIToastMessage> UIFactory::CreateToastMessage(const std::string 
     toast->SetSize({0.f, 0.f}); // still required by interface
 
     return toast;
-}
-
-/// @brief A private helper method to utilize color themes for a SkinnableButton combo.
-/// @param button Reference to the button to be changed.
-/// @param scheme Enum field representing  the type of scheme.
-void UIFactory::ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButtonColorScheme scheme)
-{
-    switch (scheme)
-    {
-        case UIButtonColorScheme::Blue:
-            button.SetTextStyle(TEX_BTN_BLUE_LABEL_TEXT_COLOR, TEX_BTN_BLUE_TEXT_OUTLINE_COLOR, 2.0f);
-            break;
-
-        case UIButtonColorScheme::Green:
-            button.SetTextStyle(TEX_BTN_GREEN_LABEL_TEXT_COLOR, TEX_BTN_GREEN_TEXT_OUTLINE_COLOR, 2.0f);
-            break;
-
-        case UIButtonColorScheme::Red:
-            button.SetTextStyle(TEX_BTN_RED_LABEL_TEXT_COLOR, TEX_BTN_RED_TEXT_OUTLINE_COLOR, 2.0f);
-            break;
-    }
 }

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -9,6 +9,7 @@
 
 #include "UIFactory.h"
 #include "AssetManager.h"
+#include "Assets.h"
 #include "Macros.h"
 #include "ResolutionScaleManager.h"
 #include "SettingsManager.h"
@@ -36,7 +37,7 @@ std::shared_ptr<UIButton> UIFactory::CreateButton(const sf::Vector2f &position, 
 
     auto btn = std::make_shared<UIButton>(position, scaledSize);
 
-    btn->SetText(label, *AssetManager::Instance().GetFont("Default"), scaledFontSize);
+    btn->SetText(label, *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey), scaledFontSize);
     btn->SetTextColor(BUTTON_DEFAULT_TEXT_COLOR);
     btn->SetCallback(std::move(onClick));
     btn->SetIdleColor(BUTTON_DEFAULT_IDLE_COLOR);
@@ -65,7 +66,7 @@ std::shared_ptr<UISelectableButton> UIFactory::CreateSelectableButton(const sf::
 
     auto btn = std::make_shared<UISelectableButton>(position, scaledSize);
 
-    btn->SetText(label, *AssetManager::Instance().GetFont("Default"), scaledFontSize);
+    btn->SetText(label, *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey), scaledFontSize);
     btn->SetTextColor(BUTTON_DEFAULT_TEXT_COLOR);
     btn->SetCallback(std::move(onClick));
     btn->SetHoverColor(BUTTON_DEFAULT_HOVER_COLOR);
@@ -95,7 +96,7 @@ std::shared_ptr<UISkinnableButton> UIFactory::CreateSkinnableButton(const sf::Ve
 
     auto btn = std::make_shared<UISkinnableButton>(pos, scaledSize);
 
-    btn->SetText(label, *AssetManager::Instance().GetFont("Default"), scaledFontSize);
+    btn->SetText(label, *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey), scaledFontSize);
     btn->SetTextureSkins(idle, hover);
     btn->ApplySkinnableButtonTextStyle(scheme);
     btn->SetCallback(onClick);
@@ -122,12 +123,12 @@ std::shared_ptr<UISlider> UIFactory::CreateSlider(const std::string &label, cons
     const sf::Vector2f scaledPos = {scaleMgr.ScaledReferenceX(position.x), scaleMgr.ScaledReferenceY(position.y)};
 
     const auto scaledSize = sf::Vector2f(scaleMgr.ScaledReferenceX(size.x), scaleMgr.ScaleY(size.y));
-    const auto scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(14);
+    const auto scaledFontSize = ResolutionScaleManager::Instance().ScaleFont(BASE_SLIDER_TITLE_FONT_SIZE);
 
     auto slider = std::make_shared<UISlider>(label, minValue, maxValue, initialValue, scaledPos, scaledSize, onChange);
-    slider->SetFont(*AssetManager::Instance().GetFont("Default"));
+    slider->SetFont(*AssetManager::Instance().GetFont(FontAssets::DefaultFontKey));
     slider->SetFontSize(scaledFontSize);
-    slider->SetTitlePositionOffset(sf::Vector2f(0.f, -ResolutionScaleManager::Instance().ScaleY(24.f)));
+    slider->SetTitlePositionOffset(sf::Vector2f(0.f, -ResolutionScaleManager::Instance().ScaleY(BASE_SLIDER_OFFSET_Y)));
 
     return slider;
 }
@@ -175,8 +176,8 @@ std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, 
     const float edgePadding = scaleMgr.ScaledReferenceY(BASE_GROUPBOX_EDGE_PAD_RATIO);
 
     auto groupBox = std::make_shared<UIGroupBox>(scaledPos, scaledSize);
-    groupBox->SetTitle(title, *AssetManager::Instance().GetFont("Default"), scaleMgr.ScaleFont(BASE_GROUPBOX_FONT_SIZE),
-                       centerOrigin, scheme);
+    groupBox->SetTitle(title, *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey),
+                       scaleMgr.ScaleFont(BASE_GROUPBOX_FONT_SIZE), centerOrigin, scheme);
     groupBox->SetLayoutMode(LayoutMode::Vertical); // safe default state
     groupBox->SetCenterChildren(true);             // safe default state
     groupBox->SetInternalPadding(internalPadding);
@@ -198,8 +199,8 @@ std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text,
 {
     const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TEXT_LABEL_BORDER_THICKNESS);
 
-    auto label = std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont("Default"), fontSize, position,
-                                               centerOrigin);
+    auto label = std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey),
+                                               fontSize, position, centerOrigin);
     label->ApplyTextLabelStyle(scheme, scaledOutline);
 
     return label;
@@ -213,7 +214,7 @@ std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text,
 std::shared_ptr<UIToastMessage> UIFactory::CreateToastMessage(const std::string &text, const sf::Vector2f &position,
                                                               float duration)
 {
-    const auto &font = *AssetManager::Instance().GetFont("Default");
+    const auto &font = *AssetManager::Instance().GetFont(FontAssets::DefaultFontKey);
     unsigned int fontSize = ResolutionScaleManager::Instance().ScaleFont(18);
     sf::Color color = sf::Color::White;
     bool centerOrigin = true;

--- a/src/core/ui/UIFactory.cpp
+++ b/src/core/ui/UIFactory.cpp
@@ -158,9 +158,12 @@ std::shared_ptr<UIArrow> UIFactory::CreateArrow(const sf::Vector2f &position, co
 /// @param title String representation for GroupBox.
 /// @param relativePosition Screen relative position to be centered around.
 /// @param relativeSize Screen relative size to occupy.
+/// @param centerOrigin Whether or not to center title text for groupbox around position.
+/// @param scheme Type of ui text label color themes.
 /// @return safe pointer to a UIGroupBox.
 std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, const sf::Vector2f &relativePosition,
-                                                      const sf::Vector2f &relativeSize, UITextLabelScheme scheme)
+                                                      const sf::Vector2f &relativeSize, bool centerOrigin,
+                                                      UITextLabelScheme scheme)
 {
     auto &scaleMgr = ResolutionScaleManager::Instance();
 
@@ -173,7 +176,7 @@ std::shared_ptr<UIGroupBox> UIFactory::CreateGroupBox(const std::string &title, 
 
     auto groupBox = std::make_shared<UIGroupBox>(scaledPos, scaledSize);
     groupBox->SetTitle(title, *AssetManager::Instance().GetFont("Default"), scaleMgr.ScaleFont(BASE_GROUPBOX_FONT_SIZE),
-                       scheme);
+                       centerOrigin, scheme);
     groupBox->SetLayoutMode(LayoutMode::Vertical); // safe default state
     groupBox->SetCenterChildren(true);             // safe default state
     groupBox->SetInternalPadding(internalPadding);
@@ -195,13 +198,8 @@ std::shared_ptr<UITextLabel> UIFactory::CreateTextLabel(const std::string &text,
 {
     const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TEXT_LABEL_BORDER_THICKNESS);
 
-    auto label = std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont("Default"), fontSize, position);
-
-    if (!centerOrigin)
-    {
-        label->SetPosition(position); // no auto-centering
-    }
-
+    auto label = std::make_shared<UITextLabel>(text, *AssetManager::Instance().GetFont("Default"), fontSize, position,
+                                               centerOrigin);
     label->ApplyTextLabelStyle(scheme, scaledOutline);
 
     return label;

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -65,7 +65,9 @@ class UIFactory
                                                  UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     std::shared_ptr<UIToastMessage> CreateToastMessage(const std::string &text, const sf::Vector2f &position,
-                                                       float duration);
+                                                       float duration, unsigned int baseFontSize,
+                                                       bool centerOrigin = true,
+                                                       UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
   private:
     UIFactory() = default;

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -57,11 +57,11 @@ class UIFactory
                                          std::function<void()> onClick);
 
     std::shared_ptr<UIGroupBox> CreateGroupBox(const std::string &title, const sf::Vector2f &relativePos,
-                                               const sf::Vector2f &relativeSize,
+                                               const sf::Vector2f &relativeSize, bool centerOrigin = true,
                                                UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     std::shared_ptr<UITextLabel> CreateTextLabel(const std::string &text, const sf::Vector2f &position,
-                                                 unsigned int baseFontSize, bool centerOrigin,
+                                                 unsigned int baseFontSize, bool centerOrigin = true,
                                                  UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     std::shared_ptr<UIToastMessage> CreateToastMessage(const std::string &text, const sf::Vector2f &position,

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -57,18 +57,18 @@ class UIFactory
                                          std::function<void()> onClick);
 
     std::shared_ptr<UIGroupBox> CreateGroupBox(const std::string &title, const sf::Vector2f &relativePos,
-                                               const sf::Vector2f &relativeSize);
+                                               const sf::Vector2f &relativeSize,
+                                               UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     std::shared_ptr<UITextLabel> CreateTextLabel(const std::string &text, const sf::Vector2f &position,
                                                  unsigned int baseFontSize, bool centerOrigin,
-                                                 UITextLabelScheme scheme);
+                                                 UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     std::shared_ptr<UIToastMessage> CreateToastMessage(const std::string &text, const sf::Vector2f &position,
                                                        float duration);
 
   private:
     void ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButtonColorScheme scheme);
-    void ApplyTextLabelStyle(UITextLabel &label, UITextLabelScheme scheme, const float labelBorderSize);
 
   private:
     UIFactory() = default;

--- a/src/core/ui/UIFactory.h
+++ b/src/core/ui/UIFactory.h
@@ -68,9 +68,6 @@ class UIFactory
                                                        float duration);
 
   private:
-    void ApplySkinnableButtonTextStyle(UISkinnableButton &button, UIButtonColorScheme scheme);
-
-  private:
     UIFactory() = default;
     ~UIFactory() = default;
 

--- a/src/core/ui/UIGroupBox.cpp
+++ b/src/core/ui/UIGroupBox.cpp
@@ -42,22 +42,28 @@ UIGroupBox::UIGroupBox(const sf::Vector2f &position, const sf::Vector2f &size)
 /// @param title String title.
 /// @param font Font loaded.
 /// @param fontSize Font size.
+/// @param centerOrigin Whether or not to center the label text around position.
 /// @param scheme Supported Color Scheme for UITextLabel.
-void UIGroupBox::SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize,
+void UIGroupBox::SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize, bool centerOrigin,
                           UITextLabelScheme scheme)
 {
     // Compute default title position just above box
     const sf::Vector2f groupBoxPos = m_background.getPosition();
-    const float paddingX = ResolutionScaleManager::Instance().ScaleX(TITLE_PAD_X);
     const float paddingY = ResolutionScaleManager::Instance().ScaleY(TITLE_PAD_Y);
 
-    m_titleLabel = UIFactory::Instance().CreateTextLabel(title, {0.f, 0.f}, fontSize, false, scheme);
+    // We will adjust the positioning after we determine the length the text field will occupy.
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(title, {0.f, 0.f}, fontSize, centerOrigin, scheme);
     sf::Vector2f textSize = m_titleLabel->GetSize();
 
-    const float anchorX = groupBoxPos.x + (textSize.x / 2.f);
-    const float aboveY = groupBoxPos.y - textSize.y - paddingY;
+    const float anchorX = groupBoxPos.x + (m_background.getSize().x / 2);
+    const float anchorY = groupBoxPos.y - textSize.y - paddingY;
 
-    m_titleLabel->SetPosition(sf::Vector2f{anchorX, aboveY});
+    m_titleLabel->SetPosition(sf::Vector2f{anchorX, anchorY});
+
+    if (centerOrigin)
+    {
+        m_titleLabel->CenterOrigin();
+    }
 
     CT_LOG_INFO("UIGroupBox SetTitle: {}.", title);
 }

--- a/src/core/ui/UIGroupBox.cpp
+++ b/src/core/ui/UIGroupBox.cpp
@@ -11,6 +11,18 @@
 
 #include "UIGroupBox.h"
 #include "Macros.h"
+#include "ResolutionScaleManager.h"
+#include "UIFactory.h"
+
+/// @brief Constants that can be adjusted throughout the UIGroupBox.
+namespace
+{
+/// @brief Default alignment padding for UITextlabel.
+constexpr float TITLE_PAD_X = 10.f;
+
+/// @brief Default alignment padding for UITextLabel.
+constexpr float TITLE_PAD_Y = 5.f;
+} // namespace
 
 /// @brief Constructor for the UIGroupBox.
 /// @param position Position to set this GroupBox.
@@ -30,18 +42,33 @@ UIGroupBox::UIGroupBox(const sf::Vector2f &position, const sf::Vector2f &size)
 /// @param title String title.
 /// @param font Font loaded.
 /// @param fontSize Font size.
-void UIGroupBox::SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize)
+/// @param scheme Supported Color Scheme for UITextLabel.
+void UIGroupBox::SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize,
+                          UITextLabelScheme scheme)
 {
-    m_title.setFont(font);
-    m_title.setString(title);
-    m_title.setCharacterSize(fontSize);
-    m_title.setFillColor(sf::Color::White);
+    // Compute default title position just above box
+    const sf::Vector2f groupBoxPos = m_background.getPosition();
+    const float paddingX = ResolutionScaleManager::Instance().ScaleX(TITLE_PAD_X);
+    const float paddingY = ResolutionScaleManager::Instance().ScaleY(TITLE_PAD_Y);
 
-    const auto bounds = m_title.getLocalBounds();
-    m_title.setOrigin(bounds.left, bounds.top);
-    m_title.setPosition(m_background.getPosition().x + 10.f, m_background.getPosition().y - bounds.height - 5.f);
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(title, {0.f, 0.f}, fontSize, false, scheme);
+    sf::Vector2f textSize = m_titleLabel->GetSize();
+
+    const float anchorX = groupBoxPos.x + (textSize.x / 2.f);
+    const float aboveY = groupBoxPos.y - textSize.y - paddingY;
+
+    m_titleLabel->SetPosition(sf::Vector2f{anchorX, aboveY});
 
     CT_LOG_INFO("UIGroupBox SetTitle: {}.", title);
+}
+
+/// @brief Provides access to the UITextLabel for altering its color scheme.
+/// @param scheme Enum field for the type of label layout.
+void UIGroupBox::SetTitleScheme(UITextLabelScheme scheme)
+{
+    const float scaledOutline = ResolutionScaleManager::Instance().ScaleX(DEFAULT_TEXT_LABEL_BORDER_THICKNESS);
+
+    m_titleLabel->ApplyTextLabelStyle(scheme, scaledOutline);
 }
 
 /// @brief Add the UIElement to the container owned by this GroupBox.
@@ -122,7 +149,11 @@ void UIGroupBox::SetPosition(const sf::Vector2f &position)
 {
     sf::Vector2f offset = position - m_background.getPosition();
     m_background.setPosition(position);
-    m_title.move(offset);
+
+    if (m_titleLabel)
+    {
+        m_titleLabel->SetPosition(m_titleLabel->GetPosition() + offset);
+    }
 
     for (auto &child : m_children)
     {
@@ -210,7 +241,11 @@ void UIGroupBox::SetEdgePadding(float padding)
 void UIGroupBox::draw(sf::RenderTarget &target, sf::RenderStates states) const
 {
     target.draw(m_background, states);
-    target.draw(m_title, states);
+
+    if (m_titleLabel)
+    {
+        target.draw(*m_titleLabel, states);
+    }
 
     for (const auto &child : m_children)
     {

--- a/src/core/ui/UIGroupBox.h
+++ b/src/core/ui/UIGroupBox.h
@@ -50,7 +50,7 @@ class UIGroupBox : public UIElement
     UIGroupBox(UIGroupBox &&) noexcept = default;
     UIGroupBox &operator=(UIGroupBox &&) noexcept = default;
 
-    void SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize = 18,
+    void SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize = 18, bool centerOrigin = true,
                   UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
     void SetTitleScheme(UITextLabelScheme scheme);
     void AddElement(std::shared_ptr<UIElement> element);

--- a/src/core/ui/UIGroupBox.h
+++ b/src/core/ui/UIGroupBox.h
@@ -13,6 +13,7 @@
 
 #include "UIElement.h"
 #include "UIPresets.h"
+#include "UITextLabel.h"
 #include <SFML/Graphics.hpp>
 #include <memory>
 #include <string>
@@ -49,7 +50,9 @@ class UIGroupBox : public UIElement
     UIGroupBox(UIGroupBox &&) noexcept = default;
     UIGroupBox &operator=(UIGroupBox &&) noexcept = default;
 
-    void SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize = 18);
+    void SetTitle(const std::string &title, const sf::Font &font, unsigned int fontSize = 18,
+                  UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
+    void SetTitleScheme(UITextLabelScheme scheme);
     void AddElement(std::shared_ptr<UIElement> element);
     void RealignChildren();
 
@@ -76,8 +79,8 @@ class UIGroupBox : public UIElement
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 
   private:
+    std::shared_ptr<UITextLabel> m_titleLabel;
     sf::RectangleShape m_background;
-    sf::Text m_title;
 
     std::vector<std::shared_ptr<UIElement>> m_children;
     LayoutMode m_layoutMode = LayoutMode::Vertical;

--- a/src/core/ui/UISkinnableButton.cpp
+++ b/src/core/ui/UISkinnableButton.cpp
@@ -179,6 +179,26 @@ void UISkinnableButton::ApplySpriteTransform()
     CenterLabel();
 }
 
+/// @brief Helper method to utilize color themes for a SkinnableButton combo.
+/// @param scheme Enum field representing  the type of scheme.
+void UISkinnableButton::ApplySkinnableButtonTextStyle(UIButtonColorScheme scheme)
+{
+    switch (scheme)
+    {
+        case UIButtonColorScheme::Blue:
+            SetTextStyle(TEX_BTN_BLUE_LABEL_TEXT_COLOR, TEX_BTN_BLUE_TEXT_OUTLINE_COLOR, 2.0f);
+            break;
+
+        case UIButtonColorScheme::Green:
+            SetTextStyle(TEX_BTN_GREEN_LABEL_TEXT_COLOR, TEX_BTN_GREEN_TEXT_OUTLINE_COLOR, 2.0f);
+            break;
+
+        case UIButtonColorScheme::Red:
+            SetTextStyle(TEX_BTN_RED_LABEL_TEXT_COLOR, TEX_BTN_RED_TEXT_OUTLINE_COLOR, 2.0f);
+            break;
+    }
+}
+
 /// @brief Returns whether or not the point is within the bounds of this UISkinnableButton.
 /// @param point Compare against us.
 /// @return true / false

--- a/src/core/ui/UISkinnableButton.h
+++ b/src/core/ui/UISkinnableButton.h
@@ -66,6 +66,7 @@ class UISkinnableButton : public UIElement
     void SetSize(const sf::Vector2f &size) override;
     sf::Vector2f GetSize() const override;
     void ApplySpriteTransform();
+    void ApplySkinnableButtonTextStyle(UIButtonColorScheme scheme);
 
     void Update(const sf::Vector2i &mousePos, bool isMousePressed, bool isMouseJustPressed, float dt) override;
     bool Contains(const sf::Vector2i &point) const override;

--- a/src/core/ui/UISlider.cpp
+++ b/src/core/ui/UISlider.cpp
@@ -11,9 +11,17 @@
 
 #include "UISlider.h"
 #include "Macros.h"
+#include "UIFactory.h"
 #include "UIPresets.h"
 #include <algorithm>
 #include <sstream>
+
+/// @brief Constants that can be adjusted throughout the UISlider.
+namespace
+{
+/// @brief Constant for UI TextLabel font size.
+constexpr unsigned int TEXT_LABEL_FONT_SIZE = 14;
+} // namespace
 
 /// @brief Constructor for the UISlider.
 /// @param label String representation for this UISlider.
@@ -56,10 +64,9 @@ void UISlider::SetupGraphics()
     // Label
     std::stringstream ss;
     ss << m_label << ": " << static_cast<int>(m_value);
-    m_labelText.setString(ss.str());
-    m_labelText.setCharacterSize(14);
-    m_labelText.setFillColor(sf::Color::White);
-    m_labelText.setPosition(m_position.x, m_position.y - 20);
+
+    m_labelText =
+        UIFactory::Instance().CreateTextLabel(ss.str(), m_position + m_labelOffset, TEXT_LABEL_FONT_SIZE, false);
 }
 
 /// @brief Returns a normalized value to be bound in min / max and value ratio.
@@ -98,7 +105,11 @@ void UISlider::Update(const sf::Vector2i &mousePos, bool isMousePressed, bool is
 
         std::stringstream ss;
         ss << m_label << ": " << static_cast<int>(m_value);
-        m_labelText.setString(ss.str());
+
+        if (m_labelText)
+        {
+            m_labelText->SetText(ss.str());
+        }
 
         if (m_onChange)
         {
@@ -128,7 +139,10 @@ void UISlider::SetPosition(const sf::Vector2f &position)
     float normalized = GetNormalizedValue();
     m_knob.setPosition(m_position.x + m_size.x * normalized, m_position.y + m_size.y / 2.f);
 
-    m_labelText.setPosition(position + m_labelOffset);
+    if (m_labelText)
+    {
+        m_labelText->SetPosition(position + m_labelOffset);
+    }
 }
 
 /// @brief Returns the position of this UISlider.
@@ -170,21 +184,31 @@ void UISlider::draw(sf::RenderTarget &target, sf::RenderStates states) const
     target.draw(m_barBackground, states);
     target.draw(m_barForeground, states);
     target.draw(m_knob, states);
-    target.draw(m_labelText, states);
+
+    if (m_labelText)
+    {
+        target.draw(*m_labelText, states);
+    }
 }
 
 /// @brief Sets the internal font for this UISlider.
 /// @param font new m_labeltext.font.
 void UISlider::SetFont(const sf::Font &font)
 {
-    m_labelText.setFont(font);
+    if (m_labelText)
+    {
+        m_labelText->SetFont(font);
+    }
 }
 
 /// @brief Sets the internal font size for this UISlider.
 /// @param size new m_labelText.size.
 void UISlider::SetFontSize(unsigned int size)
 {
-    m_labelText.setCharacterSize(size);
+    if (m_labelText)
+    {
+        m_labelText->SetFontSize(size);
+    }
 }
 
 /// @brief Sets the position for the Title on this UISlider.
@@ -192,7 +216,11 @@ void UISlider::SetFontSize(unsigned int size)
 void UISlider::SetTitlePositionOffset(const sf::Vector2f &offset)
 {
     m_labelOffset = offset;
-    m_labelText.setPosition(m_position + m_labelOffset);
+
+    if (m_labelText)
+    {
+        m_labelText->SetPosition(m_position + m_labelOffset);
+    }
 }
 
 /// @brief Sets the foreground and knob color for  this UISlider.
@@ -216,7 +244,11 @@ void UISlider::SetValue(float value)
 
     std::stringstream ss;
     ss << m_label << ": " << static_cast<int>(m_value);
-    m_labelText.setString(ss.str());
+
+    if (m_labelText)
+    {
+        m_labelText->SetText(ss.str());
+    }
 }
 
 /// @brief Gets the value for this UISlider.

--- a/src/core/ui/UISlider.cpp
+++ b/src/core/ui/UISlider.cpp
@@ -32,7 +32,7 @@ UISlider::UISlider(const std::string &label, float minValue, float maxValue, flo
     SetupGraphics();
 }
 
-/// @brief Establishes thhe necessary components that define a UISlider.
+/// @brief Establishes the necessary components that define a UISlider.
 void UISlider::SetupGraphics()
 {
     // Background bar

--- a/src/core/ui/UISlider.h
+++ b/src/core/ui/UISlider.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "UIElement.h"
+#include "UITextLabel.h"
 #include <SFML/Graphics.hpp>
 #include <functional>
 #include <string>
@@ -72,11 +73,11 @@ class UISlider : public UIElement
     sf::RectangleShape m_barBackground;
     sf::RectangleShape m_barForeground;
     sf::CircleShape m_knob;
-
-    sf::Text m_labelText;
     std::string m_label;
 
-    sf::Vector2f m_labelOffset{0.f, -20.f};
+    std::shared_ptr<UITextLabel> m_labelText;
+
+    sf::Vector2f m_labelOffset;
     sf::Vector2f m_position;
     sf::Vector2f m_size;
 

--- a/src/core/ui/UITextLabel.cpp
+++ b/src/core/ui/UITextLabel.cpp
@@ -18,15 +18,20 @@
 /// @param font Font to be used.
 /// @param fontSize Font size for label.
 /// @param position Position for label.
+/// @param centerOrigin Whether or not to center the Text around the position or not.
 UITextLabel::UITextLabel(const std::string &text, const sf::Font &font, unsigned int fontSize,
-                         const sf::Vector2f &position)
+                         const sf::Vector2f &position, bool centerOrigin)
 {
     m_text.setFont(font);
     m_text.setString(text);
     m_text.setCharacterSize(fontSize);
     m_text.setFillColor(sf::Color::White);
     m_text.setPosition(position);
-    CenterOrigin();
+
+    if (centerOrigin)
+    {
+        CenterOrigin();
+    }
 }
 
 /// @brief Sets the text for this UITextLabel.
@@ -67,6 +72,13 @@ void UITextLabel::SetOutline(float thickness, const sf::Color &color)
 {
     m_text.setOutlineThickness(thickness);
     m_text.setOutlineColor(color);
+}
+
+/// @brief Useful helper for centering the UITextLabel on the localBounds.
+void UITextLabel::CenterOrigin()
+{
+    auto bounds = m_text.getLocalBounds();
+    m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
 }
 
 /// @brief Sets the position for this UITextLabel.
@@ -140,13 +152,6 @@ sf::Vector2f UITextLabel::GetSize() const
 {
     auto bounds = m_text.getLocalBounds();
     return {bounds.width, bounds.height};
-}
-
-/// @brief Useful helper for centering the UITextLabel on the localBounds.
-void UITextLabel::CenterOrigin()
-{
-    auto bounds = m_text.getLocalBounds();
-    m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
 }
 
 /// @brief Draw this UITextLabel to the Renderable Target.

--- a/src/core/ui/UITextLabel.cpp
+++ b/src/core/ui/UITextLabel.cpp
@@ -11,6 +11,7 @@
 // ============================================================================
 
 #include "UITextLabel.h"
+#include "UIPresets.h"
 
 /// @brief Constructor for the UITextLabel.
 /// @param text String representation for this UITextLabel.
@@ -80,6 +81,51 @@ void UITextLabel::SetPosition(const sf::Vector2f &position)
 sf::Vector2f UITextLabel::GetPosition() const
 {
     return m_text.getPosition();
+}
+
+/// @brief Helper method to utilize color themes for a TextLabel string combo.
+/// @param scheme Enum field representing the type of shceme.
+/// @param labelBorderSize Size to adjust text border witdth.
+void UITextLabel::ApplyTextLabelStyle(UITextLabelScheme scheme, const float labelBorderSize)
+{
+    switch (scheme)
+    {
+        case UITextLabelScheme::DefaultScheme:
+        default:
+            // Default scheme is LimeGreen with Purple contrast border.
+            m_text.setColor(TEXT_LABEL_COLOR_LIME_GREEN);
+            m_text.setOutlineColor(TEXT_LABEL_COLOR_PURPLE_TINT);
+            m_text.setOutlineThickness(labelBorderSize);
+            break;
+
+        case UITextLabelScheme::CougarScheme:
+            // CougarScheme scheme is Crimson with Grey contrast border.
+            m_text.setColor(TEXT_LABEL_COLOR_COUGAR_CRIMSON);
+            m_text.setOutlineColor(TEXT_LABEL_COLOR_COUGAR_GREY);
+            m_text.setOutlineThickness(labelBorderSize);
+            break;
+
+        case UITextLabelScheme::HuskyScheme:
+            // HuskyScheme scheme is PurpleTint with MetallicGold contrast border.
+            m_text.setColor(TEXT_LABEL_COLOR_PURPLE_TINT);
+            m_text.setOutlineColor(TEXT_LABEL_COLOR_METALLIC_GOLD);
+            m_text.setOutlineThickness(labelBorderSize);
+            break;
+
+        case UITextLabelScheme::BlueSteelScheme:
+            // BlueSteelScheme scheme is BlueSteel with CoolGrey contrast border.
+            m_text.setColor(TEXT_LABEL_COLOR_BLUE_STEEL);
+            m_text.setOutlineColor(TEXT_LABEL_COLOR_COOL_GREY);
+            m_text.setOutlineThickness(labelBorderSize);
+            break;
+
+        case UITextLabelScheme::MintyHerbScheme:
+            // MintyHerbScheme scheme is TealMint with Dark Green contrast border.
+            m_text.setColor(TEXT_LABEL_COLOR_TEAL_MINT);
+            m_text.setOutlineColor(TEXT_LABEL_COLOR_MUTE_GREEN);
+            m_text.setOutlineThickness(labelBorderSize);
+            break;
+    }
 }
 
 /// @brief Unused for this UITextLabel currently, just for interface consistency.

--- a/src/core/ui/UITextLabel.cpp
+++ b/src/core/ui/UITextLabel.cpp
@@ -43,6 +43,13 @@ void UITextLabel::SetText(const std::string &text)
     CenterOrigin();
 }
 
+/// @brief Simple getter for this UITextLabels string content.
+/// @return m_texts string representation.
+const std::string UITextLabel::GetText() const
+{
+    return m_text.getString();
+}
+
 /// @brief Sets the font for this UITextLabel.
 /// @param font new m_text.font.
 void UITextLabel::SetFont(const sf::Font &font)
@@ -66,6 +73,13 @@ void UITextLabel::SetColor(const sf::Color &color)
     m_text.setFillColor(color);
 }
 
+/// @brief Simple getter for this UITextLabels fill color.
+/// @return m_texts fill color.
+const sf::Color UITextLabel::GetFillColor() const
+{
+    return m_text.getFillColor();
+}
+
 /// @brief Sets the outline thickness for this UITextLabel.
 /// @param thickness new outline thickness.
 /// @param color new outline color.
@@ -73,6 +87,20 @@ void UITextLabel::SetOutline(float thickness, const sf::Color &color)
 {
     m_text.setOutlineThickness(thickness);
     m_text.setOutlineColor(color);
+}
+
+/// @brief Simple getter for this UITextLabels outline color.
+/// @return m_texts outline color.
+const sf::Color UITextLabel::GetOutlineColor() const
+{
+    return m_text.getOutlineColor();
+}
+
+/// @brief Simple getter for this UITextLabels outline thickness.
+/// @return m_texts outline thickness.
+const float UITextLabel::GetOutlineThickness() const
+{
+    return m_text.getOutlineThickness();
 }
 
 /// @brief Useful helper for centering the UITextLabel on the localBounds.

--- a/src/core/ui/UITextLabel.cpp
+++ b/src/core/ui/UITextLabel.cpp
@@ -21,12 +21,13 @@
 /// @param centerOrigin Whether or not to center the Text around the position or not.
 UITextLabel::UITextLabel(const std::string &text, const sf::Font &font, unsigned int fontSize,
                          const sf::Vector2f &position, bool centerOrigin)
+    : m_centerOrigin(centerOrigin)
 {
     m_text.setFont(font);
     m_text.setString(text);
     m_text.setCharacterSize(fontSize);
     m_text.setFillColor(sf::Color::White);
-    m_text.setPosition(position);
+    SetPosition(position); // ensures consistent logic with m_centerOrigin
 
     if (centerOrigin)
     {
@@ -77,8 +78,11 @@ void UITextLabel::SetOutline(float thickness, const sf::Color &color)
 /// @brief Useful helper for centering the UITextLabel on the localBounds.
 void UITextLabel::CenterOrigin()
 {
-    auto bounds = m_text.getLocalBounds();
-    m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
+    if (m_centerOrigin)
+    {
+        auto bounds = m_text.getLocalBounds();
+        m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
+    }
 }
 
 /// @brief Sets the position for this UITextLabel.
@@ -86,6 +90,17 @@ void UITextLabel::CenterOrigin()
 void UITextLabel::SetPosition(const sf::Vector2f &position)
 {
     m_text.setPosition(position);
+
+    if (m_centerOrigin)
+    {
+        sf::FloatRect bounds = m_text.getLocalBounds();
+        m_text.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+    }
+
+    else
+    {
+        m_text.setOrigin(0.f, 0.f);
+    }
 }
 
 /// @brief Returns the current position for this UITextLabel.

--- a/src/core/ui/UITextLabel.h
+++ b/src/core/ui/UITextLabel.h
@@ -59,6 +59,8 @@ class UITextLabel : public UIElement
     void SetPosition(const sf::Vector2f &position) override;
     sf::Vector2f GetPosition() const override;
 
+    void ApplyTextLabelStyle(UITextLabelScheme scheme, const float labelBorderSize);
+
     void SetSize(const sf::Vector2f &size) override;
     sf::Vector2f GetSize() const override;
 

--- a/src/core/ui/UITextLabel.h
+++ b/src/core/ui/UITextLabel.h
@@ -79,5 +79,6 @@ class UITextLabel : public UIElement
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 
   private:
-        sf::Text m_text;
+    sf::Text m_text;
+    bool m_centerOrigin;
 };

--- a/src/core/ui/UITextLabel.h
+++ b/src/core/ui/UITextLabel.h
@@ -51,10 +51,16 @@ class UITextLabel : public UIElement
     UITextLabel &operator=(UITextLabel &&) noexcept = default;
 
     void SetText(const std::string &text);
+    const std::string GetText() const;
+
     void SetFont(const sf::Font &font);
     void SetFontSize(unsigned int size);
+
     void SetColor(const sf::Color &color);
+    const sf::Color GetFillColor() const;
     void SetOutline(float thickness, const sf::Color &color);
+    const sf::Color GetOutlineColor() const;
+    const float GetOutlineThickness() const;
 
     void CenterOrigin();
     void SetPosition(const sf::Vector2f &position) override;

--- a/src/core/ui/UITextLabel.h
+++ b/src/core/ui/UITextLabel.h
@@ -39,7 +39,7 @@ class UITextLabel : public UIElement
 {
   public:
     UITextLabel(const std::string &text, const sf::Font &font, unsigned int fontSize,
-                const sf::Vector2f &position = {0.f, 0.f});
+                const sf::Vector2f &position = {0.f, 0.f}, bool centerOrigin = true);
     ~UITextLabel() = default;
 
     // Disable copy
@@ -56,6 +56,7 @@ class UITextLabel : public UIElement
     void SetColor(const sf::Color &color);
     void SetOutline(float thickness, const sf::Color &color);
 
+    void CenterOrigin();
     void SetPosition(const sf::Vector2f &position) override;
     sf::Vector2f GetPosition() const override;
 
@@ -78,7 +79,5 @@ class UITextLabel : public UIElement
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 
   private:
-    void CenterOrigin();
-
-    sf::Text m_text;
+        sf::Text m_text;
 };

--- a/src/core/ui/UIToastMessage.cpp
+++ b/src/core/ui/UIToastMessage.cpp
@@ -11,27 +11,37 @@
 
 #include "UIToastMessage.h"
 #include "ResolutionScaleManager.h"
+#include "UIFactory.h"
 #include "WindowManager.h"
 
 /// @brief Constructor for the UIToastMessage.
 /// @param text String representation for this UIToastMessage.
 /// @param position Position for this UIToastMessage.
+/// @param fontSize Font size to initialize the UITextLabel with.
 /// @param durationSeconds Lifespan in delta time for this UIToastMessage.
-/// @param font Font to be used.
-/// @param fontSize Font size.
-/// @param textColor Color for the text fill color.
 /// @param centerOrigin Positional origin for the UIToastMessage.
-UIToastMessage::UIToastMessage(const std::string &text, const sf::Vector2f &position, float durationSeconds,
-                               const sf::Font &font, unsigned int fontSize, const sf::Color &textColor,
-                               bool centerOrigin)
+/// @param scheme Style of UITextLabel to apply to ToastMessage.
+UIToastMessage::UIToastMessage(const std::string &text, const sf::Vector2f &position, unsigned int fontSize,
+                               float durationSeconds, bool centerOrigin, UITextLabelScheme scheme)
     : m_duration(durationSeconds), m_centerOrigin(centerOrigin)
 {
-    m_text.setFont(font);
-    m_text.setString(text);
-    m_text.setCharacterSize(fontSize);
-    m_text.setFillColor(textColor);
+    m_startY = 0.f;
+    m_targetY = 0.f;
 
+    InitTextLabel(text, position, fontSize, centerOrigin, scheme);
     SetPosition(position);
+}
+
+/// @brief Initializes this Toast message with the appropriate UITextLabel style.
+/// @param text String to initialize with.
+/// @param position Position to initialize with.
+/// @param fontSize Font size to initialize with.
+/// @param centerOrigin Whether or not the center the UITextLabel about the origin.
+/// @param scheme Color scheme pattern to initialize the UITextLabel with.
+void UIToastMessage::InitTextLabel(const std::string &text, const sf::Vector2f &position, unsigned int fontSize,
+                                   bool centerOrigin, UITextLabelScheme scheme)
+{
+    m_label = UIFactory::Instance().CreateTextLabel(text, position, fontSize, centerOrigin, scheme);
 }
 
 /// @brief Performs internal state management during a single frame. Note the default update signature is in line with
@@ -52,17 +62,21 @@ void UIToastMessage::Update(const sf::Vector2i &, bool, bool, float dt)
     // Slide animation: interpolate Y position upward (toast rise)
     float t = std::min(1.f, m_elapsed / m_duration);
     float newY = m_startY + (m_targetY - m_startY) * t;
-    auto pos = m_text.getPosition();
-    m_text.setPosition(pos.x, newY);
+    auto pos = m_label->GetPosition();
+    m_label->SetPosition({pos.x, newY});
 
     // Fade out near end
     if (m_elapsed >= m_duration - m_fadeOutDuration)
     {
         float fadeT = (m_duration - m_elapsed) / m_fadeOutDuration;
         m_alpha = 255.f * std::clamp(fadeT, 0.f, 1.f);
-        auto color = m_text.getFillColor();
-        color.a = static_cast<sf::Uint8>(m_alpha);
-        m_text.setFillColor(color);
+        auto fillColor = m_label->GetFillColor();
+        auto outlineColor = m_label->GetOutlineColor();
+        float thickness = m_label->GetOutlineThickness();
+        fillColor.a = static_cast<sf::Uint8>(m_alpha);
+        outlineColor.a = static_cast<sf::Uint8>(m_alpha);
+        m_label->SetColor(fillColor);
+        m_label->SetOutline(thickness, outlineColor);
     }
 }
 
@@ -71,24 +85,13 @@ void UIToastMessage::Update(const sf::Vector2i &, bool, bool, float dt)
 /// @return true / false
 bool UIToastMessage::Contains(const sf::Vector2i &point) const
 {
-    return m_text.getGlobalBounds().contains(static_cast<sf::Vector2f>(point));
+    return m_label->Contains(point);
 }
 
 /// @brief Sets the position for this UIToastMessage.
 /// @param position new text.position.
 void UIToastMessage::SetPosition(const sf::Vector2f &position)
 {
-    if (m_centerOrigin)
-    {
-        const auto bounds = m_text.getLocalBounds();
-        m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
-    }
-
-    else
-    {
-        m_text.setOrigin(0.f, 0.f);
-    }
-
     // Calculate Y drift
     float drift = ResolutionScaleManager::Instance().ScaledReferenceY(TOAST_DEFAULT_DRIFT_PERCENTAGE);
     const auto winSize = WindowManager::Instance().GetWindow().getSize();
@@ -97,14 +100,14 @@ void UIToastMessage::SetPosition(const sf::Vector2f &position)
     m_targetY = std::min(position.y, winSize.y - drift);        // target must remain on-screen
     m_startY = std::min(position.y + drift, winSize.y - drift); // drift downward but within screen
 
-    m_text.setPosition(position.x, m_startY);
+    m_label->SetPosition({position.x, m_startY});
 }
 
 /// @brief Returns the current position for this UIToastMessage.
-/// @return m_text.position.
+/// @return m_label->position.
 sf::Vector2f UIToastMessage::GetPosition() const
 {
-    return m_text.getPosition();
+    return m_label->GetPosition();
 }
 
 /// @brief Not relevant for this UIToastMessage, but consistent with interface.
@@ -118,32 +121,29 @@ void UIToastMessage::SetSize(const sf::Vector2f &)
 /// @return size.
 sf::Vector2f UIToastMessage::GetSize() const
 {
-    const auto bounds = m_text.getGlobalBounds();
-    return {bounds.width, bounds.height};
+    return m_label->GetSize();
 }
 
 /// @brief Sets the font for this UIToastMessage.
-/// @param font new m_text.font.
+/// @param font new m_label->font.
 void UIToastMessage::SetFont(const sf::Font &font)
 {
-    m_text.setFont(font);
+    m_label->SetFont(font);
 }
 
 /// @brief Sets the font for this UIToastMessage.
-/// @param size new m_text.size.
+/// @param size new m_label->size.
 void UIToastMessage::SetFontSize(unsigned int size)
 {
-    m_text.setCharacterSize(size);
-    // Optional: Re-center origin if needed
-    sf::FloatRect bounds = m_text.getLocalBounds();
-    m_text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
+    m_label->SetFontSize(size);
 }
 
-/// @brief Sets the text fill color for this UIToastMessage.
-/// @param color new m_text.color.
-void UIToastMessage::SetColor(const sf::Color &color)
+/// @brief Calls the ApplyTextLabelStyle method of the internal UITextLabel.
+/// @param scheme The scheme or color pattern to apply.
+/// @param labelBorderSize The border thickness to utilize for the label.
+void UIToastMessage::ApplyStyle(UITextLabelScheme scheme, const float labelBorderSize)
 {
-    m_text.setFillColor(color);
+    m_label->ApplyTextLabelStyle(scheme, labelBorderSize);
 }
 
 /// @brief Returns whether or not this UIToastMessage lifespan is expired.
@@ -160,6 +160,6 @@ void UIToastMessage::draw(sf::RenderTarget &target, sf::RenderStates states) con
 {
     if (IsEnabled() && !IsExpired())
     {
-        target.draw(m_text, states);
+        target.draw(*m_label, states);
     }
 }

--- a/src/core/ui/UIToastMessage.h
+++ b/src/core/ui/UIToastMessage.h
@@ -13,6 +13,7 @@
 
 #include "UIElement.h"
 #include "UIPresets.h"
+#include "UITextLabel.h"
 #include <SFML/Graphics.hpp>
 #include <string>
 
@@ -28,8 +29,8 @@
 class UIToastMessage : public UIElement
 {
   public:
-    UIToastMessage(const std::string &text, const sf::Vector2f &position, float durationSeconds, const sf::Font &font,
-                   unsigned int fontSize = 20, const sf::Color &textColor = sf::Color::White, bool centerOrigin = true);
+    UIToastMessage(const std::string &text, const sf::Vector2f &position, unsigned int fontSize, float durationSeconds,
+                   bool centerOrigin = true, UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     ~UIToastMessage() override = default;
 
@@ -40,6 +41,9 @@ class UIToastMessage : public UIElement
     // Enable move
     UIToastMessage(UIToastMessage &&) noexcept = default;
     UIToastMessage &operator=(UIToastMessage &&) noexcept = default;
+
+    void InitTextLabel(const std::string &text, const sf::Vector2f &position, unsigned int fontSize,
+                       bool centerOrigin = true, UITextLabelScheme scheme = UITextLabelScheme::DefaultScheme);
 
     virtual void Update(const sf::Vector2i &mousePos, bool isMousePressed, bool isMouseJustPressed, float dt) override;
     bool Contains(const sf::Vector2i &point) const override;
@@ -52,7 +56,7 @@ class UIToastMessage : public UIElement
 
     void SetFont(const sf::Font &font);
     void SetFontSize(unsigned int size);
-    void SetColor(const sf::Color &color);
+    void ApplyStyle(UITextLabelScheme scheme, const float labelBorderSize);
 
     bool IsExpired() const;
 
@@ -60,7 +64,7 @@ class UIToastMessage : public UIElement
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 
   private:
-    sf::Text m_text;
+    std::shared_ptr<UITextLabel> m_label;
 
     float m_duration = TOAST_DEFAULT_DURATION;
     float m_elapsed = 0.0f;

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 2
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 6
+#define CT_VERSION_PATCH 7
 
 /// @brief String representation for Chaos Theory version.
-#define CT_VERSION_STRING "1.2.6"
+#define CT_VERSION_STRING "1.2.7"


### PR DESCRIPTION
patched: Add support for UITextLabel in solution
		- UITextLabel->CenterOrigin() method now public and used correctly
		- Adjusted centerOrigin to be true as a default parameter optional in many factory calls
		- Changed Theme to be the default theme in many factory calls
		- Added support for UITextLabel in UISlider component
		- Added support for UITextLabel in ToastMessage component
		- Added support for UITextLabel in GroupBox component
		- Updated all UIFactory methods to support new UITextLabel changes
		- Fix SkinnableButton Enum scheme to live in SkinnableButton
		- Cleaned up magic constants usage in UIFactory