### PR TITLE
V1.3.1 pause scene

### DIFF
--- a/src/core/common/Assets.h
+++ b/src/core/common/Assets.h
@@ -264,10 +264,13 @@ static const std::unordered_map<std::string, std::string> Sounds = {
     {"SettingsSound", "assets/audio/Ping.wav"},
 };
 
-/// @brief Fonts contain a Key and Value pair collection of font assets
-static const std::unordered_map<std::string, std::string> Fonts = {
-    {"Default", "assets/fonts/Default.ttf"},
-    {"SettingsFont", "assets/fonts/Default.ttf"},
+/// @brief UI contain a Key and Value pair collection of ui assets
+static const std::unordered_map<std::string, std::string> UI = {
+    {"UIArrow", "assets/ui/arrow/UIArrow.png"},
+    {"GreenButtonIdle", "assets/ui/button/green/GreenButtonIdle.png"},
+    {"GreenButtonHover", "assets/ui/button/green/GreenButtonHover.png"},
+    {"RedButtonIdle", "assets/ui/button/red/RedButtonIdle.png"},
+    {"RedButtonHover", "assets/ui/button/red/RedButtonHover.png"},
 };
 } // namespace SettingsAssets
 
@@ -275,7 +278,7 @@ static const std::unordered_map<std::string, std::string> Fonts = {
 // MainMenuScene Preconfigurable Assets for quick loading
 // ============================================================================
 
-/// @brief Exposes Textures, Fonts, and Audio assets to the MainMenuAssets namespace.
+/// @brief Exposes Textures, UI, and Audio assets to the MainMenuAssets namespace.
 namespace MainMenuAssets
 {
 /// @brief Path for the MenuSong.
@@ -289,10 +292,10 @@ static const std::unordered_map<std::string, std::string> Textures = {
     {"PlayerShip", "assets/sprites/PlayerShip.png"},
 };
 
-/// @brief Fonts contain a Key and Value pair collection of font assets
-static const std::unordered_map<std::string, std::string> Fonts = {
-    {"Default", "assets/fonts/Default.ttf"},
-    {"MenuFont", "assets/fonts/Default.ttf"},
+/// @brief UI contain a Key and Value pair collection of ui assets
+static const std::unordered_map<std::string, std::string> UI = {
+    {"BlueButtonIdle", "assets/ui/button/blue/BlueButtonIdle.png"},
+    {"BlueButtonHover", "assets/ui/button/blue/BlueButtonHover.png"},
 };
 } // namespace MainMenuAssets
 
@@ -300,7 +303,7 @@ static const std::unordered_map<std::string, std::string> Fonts = {
 // SplashScene Preconfigurable Assets for quick loading
 // ============================================================================
 
-/// @brief Exposes Textures, Fonts, and Audio assets to the SplashAssets namespace.
+/// @brief Exposes Textures, and Audio assets to the SplashAssets namespace.
 namespace SplashAssets
 {
 /// @brief Key to the Splash intro sound asset.
@@ -313,32 +316,23 @@ static auto SplashBackground = "SplashBackground";
 static const std::unordered_map<std::string, std::string> Textures = {
     {"SplashBackground", "assets/backgrounds/ChaosTheorySplash.png"},
 };
-
-/// @brief Fonts contain a Key and Value pair collection of font assets
-static const std::unordered_map<std::string, std::string> Fonts = {
-    {"Default", "assets/fonts/Default.ttf"},
-    {"SplashFont", "assets/fonts/Default.ttf"},
-};
 } // namespace SplashAssets
 
 // ============================================================================
 // SandBoxScene Preconfigurable Assets for quick loading
 // ============================================================================
 
-/// @brief Exposes Textures, Fonts, and Audio assets to the GameAssets namespace.
+/// @brief Exposes Audio, and Texture assets to the SandBoxAssets namespace.
 namespace SandBoxAssets
 {
+/// @brief Path for the GameTrack.
+constexpr auto GameTrack = "assets/audio/RootMenu.wav";
+
 /// @brief Textures contain a Key and Value pair collection of image assets
 static const std::unordered_map<std::string, std::string> Textures = {
     {"PlainStarBackground", "assets/backgrounds/PlainStarBackground.png"},
     {"GasPattern1", "assets/backgrounds/GasPattern1.png"},
     {"GasPattern2", "assets/backgrounds/GasPattern2.png"},
-};
-
-/// @brief Fonts contain a Key and Value pair collection of font assets
-static const std::unordered_map<std::string, std::string> Fonts = {
-    {"Default", "assets/fonts/Default.ttf"},
-    {"GameFont", "assets/fonts/Default.ttf"},
 };
 } // namespace SandBoxAssets
 
@@ -346,7 +340,7 @@ static const std::unordered_map<std::string, std::string> Fonts = {
 // GameScene Preconfigurable Assets for quick loading
 // ============================================================================
 
-/// @brief Exposes Textures, Fonts, and Audio assets to the GameAssets namespace.
+/// @brief Exposes Texture assets to the GameAssets namespace.
 namespace GameAssets
 {
 /// @brief Textures contain a Key and Value pair collection of image assets
@@ -355,10 +349,22 @@ static const std::unordered_map<std::string, std::string> Textures = {
     {"GasPattern1", "assets/backgrounds/GasPattern1.png"},
     {"GasPattern2", "assets/backgrounds/GasPattern2.png"},
 };
-
-/// @brief Fonts contain a Key and Value pair collection of font assets
-static const std::unordered_map<std::string, std::string> Fonts = {
-    {"Default", "assets/fonts/Default.ttf"},
-    {"GameFont", "assets/fonts/Default.ttf"},
-};
 } // namespace GameAssets
+
+// ============================================================================
+// PauseScene Preconfigurable Assets for quick loading
+// ============================================================================
+
+/// @brief Exposes UI assets to the PauseAssets namespace.
+namespace PauseAssets
+{
+/// @brief UI contain a Key and Value pair collection of ui assets
+static const std::unordered_map<std::string, std::string> UI = {
+    {"BlueButtonIdle", "assets/ui/button/blue/BlueButtonIdle.png"},
+    {"BlueButtonHover", "assets/ui/button/blue/BlueButtonHover.png"},
+    {"GreenButtonIdle", "assets/ui/button/green/GreenButtonIdle.png"},
+    {"GreenButtonHover", "assets/ui/button/green/GreenButtonHover.png"},
+    {"RedButtonIdle", "assets/ui/button/red/RedButtonIdle.png"},
+    {"RedButtonHover", "assets/ui/button/red/RedButtonHover.png"},
+};
+} // namespace PauseAssets

--- a/src/core/scenes/MainMenuScene.cpp
+++ b/src/core/scenes/MainMenuScene.cpp
@@ -87,16 +87,16 @@ void MainMenuScene::Init()
     CT_LOG_INFO("MainMenuScene initialized.");
 }
 
-/// @brief Load any required assets listed in the MainMenuAssets namespace.
+/// @brief Load any required assets relevant to the MainMenuScene.
 void MainMenuScene::LoadRequiredAssets()
 {
     auto &assets = AssetManager::Instance();
 
-    for (const auto &[key, path] : UIAssets::Textures)
+    for (const auto &[key, path] : MainMenuAssets::UI)
     {
         if (!AssetManager::Instance().LoadTexture(key, path))
         {
-            CT_LOG_ERROR("MainMenuScene::LoadRequiredAssets::LoadTexture failed to load asset: {}, {}", key, path);
+            CT_LOG_ERROR("MainMenuScene::LoadRequiredAssets::UI failed to load asset: {}, {}", key, path);
         }
     }
 
@@ -108,7 +108,7 @@ void MainMenuScene::LoadRequiredAssets()
         }
     }
 
-    for (const auto &[key, path] : MainMenuAssets::Fonts)
+    for (const auto &[key, path] : FontAssets::Fonts)
     {
         if (!assets.LoadFont(key, path))
         {
@@ -301,11 +301,13 @@ void MainMenuScene::CreateButtons()
 void MainMenuScene::LoadBackground()
 {
     m_background = std::make_unique<Background>();
-    m_background->InitParallax({{"GasPattern1", 2.f}, {"PlainStarBackground", 1.f}, {"GasPattern2", 4.f}});
+    m_background->InitParallax({{BackgroundAssets::GasPattern1BackgroundKey, 2.f},
+                                {BackgroundAssets::PlainStarBackgroundKey, 1.f},
+                                {BackgroundAssets::GasPattern2BackgroundKey, 4.f}});
 
-    m_background->SetLayerMotion("GasPattern1", {-1.f, 0.f});
-    m_background->SetLayerMotion("GasPattern2", {1.f, 0.f});
-    m_background->SetLayerMotion("PlainStarBackground", {1.f, .33f});
+    m_background->SetLayerMotion(BackgroundAssets::GasPattern1BackgroundKey, {-1.f, 0.f});
+    m_background->SetLayerMotion(BackgroundAssets::GasPattern2BackgroundKey, {1.f, 0.f});
+    m_background->SetLayerMotion(BackgroundAssets::PlainStarBackgroundKey, {1.f, .33f});
 
     CT_LOG_INFO("Menu background loaded and scaled.");
 }
@@ -329,7 +331,7 @@ void MainMenuScene::PlayIntroMusic()
 /// @brief Helper method for setting up the travelling spaceship.
 void MainMenuScene::InitShip()
 {
-    auto tex = AssetManager::Instance().GetTexture("PlayerShip");
+    auto tex = AssetManager::Instance().GetTexture(SpriteAssets::PlayerShipSpriteKey);
 
     if (!tex)
     {

--- a/src/core/scenes/PauseScene.cpp
+++ b/src/core/scenes/PauseScene.cpp
@@ -1,0 +1,258 @@
+// ============================================================================
+//  File        : PauseScene.cpp
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-06-109
+//  Description : Hosts the definitions for Pause Scene Object
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#include "PauseScene.h"
+#include "AssetManager.h"
+#include "Assets.h"
+#include "AudioManager.h"
+#include "InputManager.h"
+#include "Macros.h"
+#include "MainMenuScene.h"
+#include "ResolutionScaleManager.h"
+#include "SceneManager.h"
+#include "SceneTransitionManager.h"
+#include "SettingsScene.h"
+#include "UIFactory.h"
+#include "UIManager.h"
+#include "WindowManager.h"
+
+/// @brief Constants that can be adjusted throughout the PauseScene.
+namespace
+{
+/// @brief Fixed name constant for the pause title label.
+constexpr auto PAUSE_TITLE_LABEL = "Paused";
+
+/// @brief Fixed name constant for the settings button label.
+constexpr auto SETTINGS_BTN_LABEL = "Settings";
+
+/// @brief Fixed name constant for the resume button label.
+constexpr auto RESUME_BTN_LABEL = "Resume";
+
+/// @brief Fixed name constant for the return button label.
+constexpr auto RETURN_BTN_LABEL = "Return to Menu";
+} // namespace
+
+/// @brief Constructor for the PauseScene.
+/// @param settings Internal settings to initialize with.
+PauseScene::PauseScene(std::shared_ptr<Settings> settings) : m_settings(settings)
+{
+}
+
+/// @brief Initializes the PauseScene.
+void PauseScene::Init()
+{
+    CF_EXIT_EARLY_IF_ALREADY_INITIALIZED();
+
+    UIManager::Instance().Clear();
+
+    LoadRequiredAssets();
+    PauseAudio();
+    SetupUI();
+
+    m_isInitialized = true;
+
+    CT_LOG_INFO("PauseScene initialized.");
+}
+
+/// @brief Load any required assets relevant to the PauseScene.
+void PauseScene::LoadRequiredAssets()
+{
+    auto &assets = AssetManager::Instance();
+
+    for (const auto &[key, path] : PauseAssets::UI)
+    {
+        if (!AssetManager::Instance().LoadTexture(key, path))
+        {
+            CT_LOG_ERROR("PauseScene::LoadRequiredAssets::LoadTexture failed to load asset: {}, {}", key, path);
+        }
+    }
+
+    for (const auto &[key, path] : FontAssets::Fonts)
+    {
+        if (!assets.LoadFont(key, path))
+        {
+            CT_LOG_ERROR("PauseScene::LoadRequiredAssets::LoadFont failed to load Asset: {}, {}", key, path);
+        }
+    }
+
+    CT_LOG_INFO("PauseScene finished LoadRequiredAssets.");
+}
+
+/// @brief Shuts down this scene and resets internal state.
+void PauseScene::Shutdown()
+{
+    CT_WARN_IF_UNINITIALIZED("PauseScene", "Shutdown");
+
+    UIManager::Instance().Clear();
+    m_settings.reset();
+    m_isInitialized = false;
+
+    CT_LOG_INFO("PauseScene Shutdown.");
+}
+
+/// @brief Handle any relevent exit criteria if needed.
+void PauseScene::OnExit()
+{
+    AudioManager::Instance().ResumeMusic();
+
+    CT_LOG_INFO("PauseScene OnExit.");
+}
+
+/// @brief Resumes Scene in event of a Pause. This can be triggered by returning from the Pause Menu's Setting page go
+/// back.
+void PauseScene::OnResume()
+{
+    UIManager::Instance().Clear();
+    SetupUI();
+    CT_LOG_INFO("PauseScene resumed and UI restored.");
+}
+
+/// @brief Performs internal state management during a single frame.
+/// @param dt delta time since last update.
+void PauseScene::Update(float dt)
+{
+    const auto mousePos = InputManager::Instance().GetMousePosition();
+    const bool isPressed = InputManager::Instance().IsMouseButtonPressed(sf::Mouse::Left);
+    const bool isJustPressed = InputManager::Instance().IsMouseButtonJustPressed(sf::Mouse::Left);
+
+    UIManager::Instance().Update(mousePos, isPressed, isJustPressed, dt);
+
+    if (m_hasPendingTransition)
+    {
+        if (m_requestedScene == SceneID::Settings)
+        {
+            CT_LOG_INFO("PauseScene pushing Settings page.");
+            m_hasPendingTransition = false;
+
+            SceneManager::Instance().PushScene(
+                std::make_unique<SettingsScene>(m_settings, false,
+                                                []()
+                                                {
+                                                    SceneManager::Instance().DeferPopScene(); // Return to PauseScene
+                                                }));
+        }
+
+        else if (m_requestedScene == SceneID::MainMenu)
+        {
+            CT_LOG_INFO("PauseScene Requesting Scene Change to '{}'", SceneIDToString(m_requestedScene));
+            m_hasPendingTransition = false;
+            SceneID tempState = m_requestedScene;
+
+            // <-- kill this scene = sandbox scene exists, then request that be changed.
+            SceneTransitionManager::Instance().ForceFullyOpaque();
+            SceneManager::Instance().PopScene();
+            SceneManager::Instance().RequestSceneChange(tempState);
+        }
+    }
+
+    else if (m_shouldExit)
+    {
+        m_shouldExit = false;
+        SceneManager::Instance().PopScene();
+
+        CT_LOG_INFO("PauseScene requested exit. Popping scene...");
+    }
+}
+
+/// @brief Handle any quick cancelation requests if present.
+/// @param event bubbled down from caller, not needed.
+void PauseScene::HandleEvent(const sf::Event &event)
+{
+}
+
+/// @brief Not used in PauseScene context.
+/// @param newSize bubbled down from caller, not needed.
+void PauseScene::OnResize(const sf::Vector2u &newSize)
+{
+}
+
+/// @brief While this scene is active, render the necessary components.
+void PauseScene::Render()
+{
+    CT_WARN_IF_UNINITIALIZED("PauseScene", "Render");
+
+    auto &window = WindowManager::Instance().GetWindow();
+
+    // Optional: Draw dimming overlay
+    sf::RectangleShape overlay;
+    overlay.setSize(sf::Vector2f(window.getSize()));
+    overlay.setFillColor(sf::Color(0, 0, 0, 150)); // 150 alpha to dim
+    window.draw(overlay);
+
+    UIManager::Instance().Render(window);
+}
+
+/// @brief Creates the necessary components for the PauseScene.
+void PauseScene::SetupUI()
+{
+    auto &scaleMgr = ResolutionScaleManager::Instance();
+
+    const std::string title = PAUSE_TITLE_LABEL;
+    const sf::Vector2f relativePos{0.375f, 0.30f}; // Centered box
+    const sf::Vector2f relativeSize{0.25f, 0.40f}; // 1/4 width, 40% height
+
+    // Create transparent group box
+    auto groupBox = UIFactory::Instance().CreateGroupBox(title, relativePos, relativeSize);
+    groupBox->SetEdgePadding(scaleMgr.ScaledReferenceY(.02f));
+    groupBox->SetInternalPadding(scaleMgr.ScaledReferenceY(.08f * relativeSize.y));
+    groupBox->SetOutlineColor(sf::Color::Transparent);
+    groupBox->SetOutlineThickness(0.f);
+    groupBox->SetFillColor(sf::Color(0, 0, 0, 0)); // Transparent background
+
+    const sf::Vector2f buttonSize = {BASE_BUTTON_WIDTH_PIXEL, BASE_BUTTON_HEIGHT_PIXEL};
+
+    // === 1. UNPAUSE GAME ===
+    auto btnResume = UIFactory::Instance().CreateSkinnableButton(
+        {0.f, 0.f}, buttonSize, RESUME_BTN_LABEL, UIAssets::UISkinButtonBlueIdleKey, UIAssets::UISkinButtonBlueHoverKey,
+        UIButtonColorScheme::Blue,
+        [this]()
+        {
+            m_shouldExit = true;
+            CT_LOG_INFO("PauseScene: Unpause Button Clicked.");
+        });
+
+    // === 2. SETTINGS ===
+    auto btnSettings = UIFactory::Instance().CreateSkinnableButton(
+        {0.f, 0.f}, buttonSize, SETTINGS_BTN_LABEL, UIAssets::UISkinButtonGreenIdleKey,
+        UIAssets::UISkinButtonGreenHoverKey, UIButtonColorScheme::Green,
+        [this]()
+        {
+            m_hasPendingTransition = true;
+            m_requestedScene = SceneID::Settings;
+            CT_LOG_INFO("PauseScene: Settings Button Clicked.");
+        });
+
+    // === 3. RETURN TO MENU ===
+    auto btnReturn = UIFactory::Instance().CreateSkinnableButton(
+        {0.f, 0.f}, buttonSize, RETURN_BTN_LABEL, UIAssets::UISkinButtonRedIdleKey, UIAssets::UISkinButtonRedHoverKey,
+        UIButtonColorScheme::Red,
+        [this]()
+        {
+            m_hasPendingTransition = true;
+            m_requestedScene = SceneID::MainMenu;
+            CT_LOG_INFO("PauseScene: Return to Menu Button Clicked.");
+        });
+
+    groupBox->AddElement(btnResume);
+    groupBox->AddElement(btnSettings);
+    groupBox->AddElement(btnReturn);
+
+    UIManager::Instance().AddElement(groupBox);
+}
+
+/// @brief Halts any current playing audio from the AudioManager.
+void PauseScene::PauseAudio()
+{
+    if (AudioManager::Instance().IsInitialized())
+    {
+        AudioManager::Instance().PauseMusic();
+    }
+}

--- a/src/core/scenes/PauseScene.h
+++ b/src/core/scenes/PauseScene.h
@@ -1,0 +1,53 @@
+// ============================================================================
+//  File        : PauseScene.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-06-09
+//  Description : Hosts the definitions for Pause Scene Object
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+#include "SceneManager.h"
+#include "Settings.h"
+#include <memory>
+
+// ============================================================================
+//  Class       : PauseScene
+//  Purpose     : Scene that displays over top of the Current Game Scene.
+//                Provides options and halts game sounds and updates.
+//
+//  Responsibilities:
+//      - Provides Menu options
+//      - Able to adjust Settings
+//      - Handle user interaction and route scene transitions
+//
+// ============================================================================
+class PauseScene : public Scene
+{
+  public:
+    PauseScene(std::shared_ptr<Settings> settings);
+    ~PauseScene() = default;
+
+    void Init() override;
+    void LoadRequiredAssets() override;
+    void Shutdown() override;
+    void OnExit() override;
+    void OnResume() override;
+
+    void Update(float dt) override;
+    void HandleEvent(const sf::Event &event) override;
+    void OnResize(const sf::Vector2u &newSize) override;
+    void Render() override;
+
+  private:
+    void SetupUI();
+    void PauseAudio();
+
+  private:
+    std::shared_ptr<Settings> m_settings;
+
+    SceneID m_requestedScene;
+};

--- a/src/core/scenes/SandBoxScene.cpp
+++ b/src/core/scenes/SandBoxScene.cpp
@@ -16,6 +16,7 @@
 #include "InputManager.h"
 #include "Macros.h"
 #include "MainMenuScene.h"
+#include "PauseScene.h"
 #include "ResolutionScaleManager.h"
 #include "SceneFactory.h"
 #include "SceneTransitionManager.h"
@@ -27,18 +28,14 @@
 /// @brief Constants that can be adjusted throughout the SandBoxScene.
 namespace
 {
-/// @brief Fixed name constant for the play button label.
-constexpr auto PLAY_BTN_LABEL = "Play";
+/// @brief Fixed name constant for the title of the Sandbox Scene.
+constexpr auto TITLE_SCREEN_LABEL = "Sandbox Scene";
 
-/// @brief Fixed name constant for the Settings button label.
-constexpr auto SETTING_BTN_LABEL = "Settings";
+/// @brief Fixed name constant for a helpful placeholder to pause the game.
+constexpr auto PAUSE_GAME_LABEL = "Press Spacebar to Pause";
 
-/// @brief Fixed name constant for the Quit button label.
-constexpr auto QUIT_BTN_LABEL = "Quit";
-
-constexpr auto TOGGLE_BUTTON_KEY = "Toggle";
-
-constexpr auto RETURN_BUTTON_KEY = "Return";
+/// @brief Fixed name constant to be used with BindActionKey to setup a pause key.
+constexpr auto PAUSE_BUTTON_KEY = "Pause";
 } // namespace
 
 /// @brief Constructor for the SandBoxScene.
@@ -47,7 +44,7 @@ SandBoxScene::SandBoxScene(std::shared_ptr<Settings> settings) : m_settings(sett
 {
 }
 
-/// @brief  Initializes the SandBoxScene.
+/// @brief Initializes the SandBoxScene.
 void SandBoxScene::Init()
 {
     CF_EXIT_EARLY_IF_ALREADY_INITIALIZED();
@@ -56,6 +53,7 @@ void SandBoxScene::Init()
 
     LoadRequiredAssets();
     BindInputKeys();
+    LoadBackground();
     SetupSceneComponents();
 
     SceneTransitionManager::Instance().StartFadeIn();
@@ -67,14 +65,6 @@ void SandBoxScene::Init()
 /// @brief Load any required assets relevant to the SandBoxScene.
 void SandBoxScene::LoadRequiredAssets()
 {
-    for (const auto &[key, path] : UIAssets::Textures)
-    {
-        if (!AssetManager::Instance().LoadTexture(key, path))
-        {
-            CT_LOG_ERROR("SandBoxScene failed to load texture asset: {} -> {}", key, path);
-        }
-    }
-
     for (const auto &[key, path] : SandBoxAssets::Textures)
     {
         if (!AssetManager::Instance().LoadTexture(key, path))
@@ -83,7 +73,7 @@ void SandBoxScene::LoadRequiredAssets()
         }
     }
 
-    for (const auto &[key, path] : SandBoxAssets::Fonts)
+    for (const auto &[key, path] : FontAssets::Fonts)
     {
         if (!AssetManager::Instance().LoadFont(key, path))
         {
@@ -108,10 +98,18 @@ void SandBoxScene::Shutdown()
 /// @brief Handles the exit criteria for this scene.
 void SandBoxScene::OnExit()
 {
-    InputManager::Instance().UnbindKey(TOGGLE_BUTTON_KEY);
-    InputManager::Instance().UnbindKey(RETURN_BUTTON_KEY);
+    InputManager::Instance().UnbindKey(PAUSE_BUTTON_KEY);
 
     CT_LOG_INFO("SandBoxScene OnExit.");
+}
+
+/// @brief Resumes Scene in event of a Pause.
+void SandBoxScene::OnResume()
+{
+    UIManager::Instance().Clear();
+    SetupSceneComponents();
+
+    CT_LOG_INFO("SandBoxScene resumed and UI restored.");
 }
 
 /// @brief Performs internal state management during a single frame.
@@ -129,16 +127,18 @@ void SandBoxScene::Update(float dt)
         m_background->Update(dt);
     }
 
-    // new
     CheckActionsPressed();
 
     // Handle button scene request change
     if (m_hasPendingTransition)
     {
-        CT_LOG_INFO("SandBoxScene Requesting Scene Change to '{}'", SceneIDToString(m_requestedScene));
-        m_hasPendingTransition = false;
-        SceneTransitionManager::Instance().ForceFullyOpaque();
-        SceneManager::Instance().RequestSceneChange(m_requestedScene);
+        if (m_requestedScene == SceneID::Pause)
+        {
+            CT_LOG_INFO("SandBoxScene Pause Event Requested.");
+
+            m_hasPendingTransition = false;
+            SceneManager::Instance().PushScene(std::make_unique<PauseScene>(m_settings));
+        }
     }
 }
 
@@ -171,7 +171,6 @@ void SandBoxScene::Render()
 /// @brief Helper method to initialize necessary Scene components.
 void SandBoxScene::SetupSceneComponents()
 {
-    LoadBackground();
     CreateTitleText();
     PlayGameMusic();
 }
@@ -180,10 +179,11 @@ void SandBoxScene::SetupSceneComponents()
 void SandBoxScene::LoadBackground()
 {
     m_background = std::make_unique<Background>();
-    m_background->InitParallax({{"GasPattern1", 2.f}, {"PlainStarBackground", 1.f}});
+    m_background->InitParallax(
+        {{BackgroundAssets::GasPattern1BackgroundKey, 2.f}, {BackgroundAssets::PlainStarBackgroundKey, 1.f}});
 
-    m_background->SetLayerMotion("PlainStarBackground", {0.2f, -0.5f});
-    m_background->SetLayerMotion("GasPattern1", {0.f, -0.1f});
+    m_background->SetLayerMotion(BackgroundAssets::PlainStarBackgroundKey, {0.2f, -0.5f});
+    m_background->SetLayerMotion(BackgroundAssets::GasPattern1BackgroundKey, {0.f, -0.1f});
 }
 
 /// @brief Helper method to create the Title string entity for this scene.
@@ -191,43 +191,58 @@ void SandBoxScene::CreateTitleText()
 {
     auto &scaleMgr = ResolutionScaleManager::Instance();
 
-    const std::string title = "Sandbox Scene";
-    const unsigned int fontSize = scaleMgr.ScaleFont(48);
-    const sf::Vector2f centerPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
-                                    scaleMgr.ScaledReferenceY(0.08f)};
+    const std::string titleLabel = TITLE_SCREEN_LABEL;
+    const unsigned int titleFontSize = scaleMgr.ScaleFont(48);
+    const sf::Vector2f titlePos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
+                                   scaleMgr.ScaledReferenceY(0.08f)};
 
-    m_titleLabel =
-        UIFactory::Instance().CreateTextLabel(title, centerPos, fontSize, true, UITextLabelScheme::MintyHerbScheme);
+    const std::string helpLabel = PAUSE_GAME_LABEL;
+    const unsigned int helpFontSize = scaleMgr.ScaleFont(20);
+    const sf::Vector2f helpPos = {WindowManager::Instance().GetWindow().getSize().x / 2.f,
+                                  scaleMgr.ScaledReferenceY(0.20f)};
+
+    m_titleLabel = UIFactory::Instance().CreateTextLabel(titleLabel, titlePos, titleFontSize, true,
+                                                         UITextLabelScheme::MintyHerbScheme);
+
+    m_helpLabel = UIFactory::Instance().CreateTextLabel(helpLabel, helpPos, helpFontSize, true,
+                                                        UITextLabelScheme::MintyHerbScheme);
+
     UIManager::Instance().AddElement(m_titleLabel);
+    UIManager::Instance().AddElement(m_helpLabel);
 }
 
-/// @brief Helper method to load and play the game music for this scene. (intentionally blank for now)
+/// @brief Helper method to load and play the game music for this scene.
 void SandBoxScene::PlayGameMusic()
 {
+    if (!AudioManager::Instance().IsMusicPlaying() ||
+        AudioManager::Instance().GetCurrentMusicName() != SandBoxAssets::GameTrack)
+    {
+        CT_LOG_INFO("SandBoxScene: Starting or resuming menu music.");
+        AudioManager::Instance().PlayMusic(SandBoxAssets::GameTrack, true);
+    }
+
+    else
+    {
+        CT_LOG_INFO("SandBoxScene: Menu music already playing, no action needed.");
+    }
 }
 
+/// @brief Sets up keyboard inputs that can be picked up during scene lifetime.
 void SandBoxScene::BindInputKeys()
 {
-    InputManager::Instance().BindKey(TOGGLE_BUTTON_KEY, sf::Keyboard::Key::Space);
-    InputManager::Instance().BindKey(RETURN_BUTTON_KEY, sf::Keyboard::Key::Enter);
+    InputManager::Instance().BindKey(PAUSE_BUTTON_KEY, sf::Keyboard::Key::Space);
 }
 
+/// @brief Determines if any configured keyboard input has been pressed during scene update.
 void SandBoxScene::CheckActionsPressed()
 {
     auto &input = InputManager::Instance();
 
-    if (input.IsKeyJustPressed(TOGGLE_BUTTON_KEY))
+    if (input.IsKeyJustPressed(PAUSE_BUTTON_KEY))
     {
-        m_toggler = !m_toggler;
+        CT_LOG_INFO("SandBoxScene: Toggle Button Pressed.");
 
-        CT_LOG_INFO("SandBoxScene: Toggle switch: {}", m_toggler);
-    }
-
-    if (input.IsKeyJustPressed(RETURN_BUTTON_KEY))
-    {
         m_hasPendingTransition = true;
-        m_requestedScene = SceneID::MainMenu;
-
-        CT_LOG_INFO("SandBoxScene: Enter event handled.");
+        m_requestedScene = SceneID::Pause;
     }
 }

--- a/src/core/scenes/SandBoxScene.h
+++ b/src/core/scenes/SandBoxScene.h
@@ -43,6 +43,7 @@ class SandBoxScene final : public Scene
     void LoadRequiredAssets() override;
     void Shutdown() override;
     void OnExit() override;
+    void OnResume() override;
 
     void Update(float dt) override;
     void HandleEvent(const sf::Event &event) override;
@@ -60,8 +61,7 @@ class SandBoxScene final : public Scene
   private:
     std::shared_ptr<Settings> m_settings;
     std::shared_ptr<UITextLabel> m_titleLabel;
+    std::shared_ptr<UITextLabel> m_helpLabel;
     std::unique_ptr<Background> m_background;
     SceneID m_requestedScene;
-
-    bool m_toggler = true;
 };

--- a/src/core/scenes/Scene.h
+++ b/src/core/scenes/Scene.h
@@ -39,6 +39,9 @@ class Scene
     virtual void LoadRequiredAssets() = 0;
     virtual void Shutdown() = 0;
     virtual void OnExit() = 0;
+    virtual void OnResume()
+    {
+    }
 
     virtual void Update(float dt) = 0;
     virtual void HandleEvent(const sf::Event &event) = 0;

--- a/src/core/scenes/SceneManager.cpp
+++ b/src/core/scenes/SceneManager.cpp
@@ -14,6 +14,7 @@
 #include "GameScene.h"
 #include "Macros.h"
 #include "MainMenuScene.h"
+#include "PauseScene.h"
 #include "SandBoxScene.h"
 #include "SettingsScene.h"
 #include "SplashScene.h"
@@ -47,13 +48,13 @@ void SceneManager::Shutdown()
 
     while (!m_scenes.empty())
     {
-        if (m_scenes.top())
+        if (m_scenes.back())
         {
-            m_scenes.top()->OnExit();
-            m_scenes.top()->Shutdown();
+            m_scenes.back()->OnExit();
+            m_scenes.back()->Shutdown();
         }
 
-        m_scenes.pop();
+        m_scenes.pop_back();
     }
 
     m_settings.reset();
@@ -78,8 +79,14 @@ void SceneManager::Update(float dt)
 
     if (!m_scenes.empty())
     {
-        auto &scene = m_scenes.top();
+        auto &scene = m_scenes.back();
         scene->Update(dt);
+    }
+
+    if (m_deferredPop)
+    {
+        PopScene();
+        m_deferredPop = false;
     }
 }
 
@@ -91,7 +98,7 @@ void SceneManager::HandleEvent(const sf::Event &event)
 
     if (!m_scenes.empty())
     {
-        m_scenes.top()->HandleEvent(event);
+        m_scenes.back()->HandleEvent(event);
     }
 }
 
@@ -100,10 +107,19 @@ void SceneManager::Render()
 {
     CT_WARN_IF_UNINITIALIZED("SceneManager", "Render");
 
-    if (!m_scenes.empty())
+    if (m_scenes.empty())
     {
-        m_scenes.top()->Render();
+        return;
     }
+
+    // If there's more than one scene, render the one below the top (background) in the case of "PauseScene"
+    if (m_scenes.size() >= 2)
+    {
+        m_scenes[m_scenes.size() - 2]->Render(); // background scene
+    }
+
+    // Always render the top scene
+    m_scenes.back()->Render();
 }
 
 /// @brief Registers a callback function for a scene by ID.
@@ -131,6 +147,7 @@ void SceneManager::RegisterAllDefaultScenes()
     Register(SceneID::Settings, [this]() { return std::make_unique<SettingsScene>(m_settings); });
     Register(SceneID::SandBox, [this]() { return std::make_unique<SandBoxScene>(m_settings); });
     Register(SceneID::Game, [this]() { return std::make_unique<GameScene>(m_settings); });
+    Register(SceneID::Pause, [this]() { return std::make_unique<PauseScene>(m_settings); });
 
     CT_LOG_INFO("All default scenes registered.");
 }
@@ -163,8 +180,10 @@ void SceneManager::PushScene(std::unique_ptr<Scene> scene)
     {
         scene->Init();
         CT_LOG_INFO("Pushing new scene: {}", typeid(*scene).name());
-        m_scenes.push(std::move(scene));
+        m_scenes.push_back(std::move(scene));
     }
+
+    CT_LOG_INFO("Scene stack size is now {}", m_scenes.size());
 }
 
 /// @brief Remove the top scene from the collection of scenes.
@@ -174,11 +193,24 @@ void SceneManager::PopScene()
 
     if (!m_scenes.empty())
     {
-        CT_LOG_INFO("Popping scene: {}", typeid(*m_scenes.top()).name());
-        m_scenes.top()->OnExit();
-        m_scenes.top()->Shutdown();
-        m_scenes.pop();
+        CT_LOG_INFO("Popping scene: {}", typeid(*m_scenes.back()).name());
+        m_scenes.back()->OnExit();
+        m_scenes.back()->Shutdown();
+        m_scenes.pop_back();
+
+        if (!m_scenes.empty())
+        {
+            m_scenes.back()->OnResume();
+        }
     }
+
+    CT_LOG_INFO("Scene stack size is now {}", m_scenes.size());
+}
+
+/// @brief Mechanism to pop a scene at the end of a update cycle for guaranteed safety.
+void SceneManager::DeferPopScene()
+{
+    m_deferredPop = true;
 }
 
 /// @brief Current scene is removed, and then newScene is added to the m_scenes list
@@ -198,9 +230,9 @@ void SceneManager::ClearScenes()
 
     while (!m_scenes.empty())
     {
-        m_scenes.top()->OnExit();
-        m_scenes.top().reset();
-        m_scenes.pop();
+        m_scenes.back()->OnExit();
+        m_scenes.back()->Shutdown();
+        m_scenes.pop_back();
     }
 
     CT_LOG_INFO("All scenes cleared.");
@@ -244,7 +276,7 @@ Scene *SceneManager::GetActiveScene() const
         return nullptr;
     }
 
-    return m_scenes.top().get();
+    return m_scenes.back().get();
 }
 
 /// @brief Request that a scene transition based on ID immediately take place. Generally used by individual Scenes logic

--- a/src/core/scenes/SceneManager.h
+++ b/src/core/scenes/SceneManager.h
@@ -15,7 +15,7 @@
 #include "Scene.h"
 #include "Settings.h"
 #include <memory>
-#include <stack>
+#include <vector>
 
 /// @brief Simple enumeration field to represent a type of scene.
 enum class SceneID
@@ -25,6 +25,7 @@ enum class SceneID
     Settings,
     SandBox,
     Game,
+    Pause
 };
 
 /// @brief Utility function to convert SceneID to string
@@ -44,6 +45,8 @@ inline const char *SceneIDToString(SceneID id)
             return "SandBox";
         case SceneID::Game:
             return "Game";
+        case SceneID::Pause:
+            return "Pause";
         default:
             return "Unknown";
     }
@@ -79,6 +82,7 @@ class SceneManager
 
     void PushScene(std::unique_ptr<Scene> scene);
     void PopScene();
+    void DeferPopScene();
     void ReplaceScene(std::unique_ptr<Scene> newScene);
     void ClearScenes();
 
@@ -98,7 +102,9 @@ class SceneManager
 
   private:
     std::unordered_map<SceneID, SceneCreateFunc> m_sceneRegistry;
-    std::stack<std::unique_ptr<Scene>> m_scenes;
+    std::vector<std::unique_ptr<Scene>> m_scenes;
     std::shared_ptr<Settings> m_settings;
+
     bool m_isInitialized = false;
+    bool m_deferredPop = false;
 };

--- a/src/core/scenes/SettingsScene.cpp
+++ b/src/core/scenes/SettingsScene.cpp
@@ -82,8 +82,11 @@ constexpr float MAX_SLIDER_VALUE = 100.f;
 } // namespace
 
 /// @brief Constructor for the SettingsScene.
-/// @param settings Internal settings to initialize with.
-SettingsScene::SettingsScene(std::shared_ptr<Settings> settings) : m_settings(settings)
+/// @param settings Settings to initialize with.
+/// @param includeDifficulty Optional difficulty page displayed on this settingsScene or disabled?
+/// @param onReturn Optional function callback  to embed into this scene for management flow.
+SettingsScene::SettingsScene(std::shared_ptr<Settings> settings, bool includeDifficulty, ReturnCallback onReturn)
+    : m_settings(settings), m_onReturn(std::move(onReturn)), m_includeDifficultyPage(includeDifficulty)
 {
 }
 
@@ -107,16 +110,16 @@ void SettingsScene::Init()
     CT_LOG_INFO("SettingsScene initialized.");
 }
 
-/// @brief Load any required assets listed in the SettingsAssets namespace.
+/// @brief Load any required assets relevant to the SettingsScene.
 void SettingsScene::LoadRequiredAssets()
 {
     auto &assets = AssetManager::Instance();
 
-    for (const auto &[key, path] : UIAssets::Textures)
+    for (const auto &[key, path] : SettingsAssets::UI)
     {
         if (!AssetManager::Instance().LoadTexture(key, path))
         {
-            CT_LOG_ERROR("MainMenuScene::LoadRequiredAssets::LoadTexture failed to load asset: {}, {}", key, path);
+            CT_LOG_ERROR("SettingsScene::LoadRequiredAssets::LoadTexture failed to load asset: {}, {}", key, path);
         }
     }
 
@@ -136,7 +139,7 @@ void SettingsScene::LoadRequiredAssets()
         }
     }
 
-    for (const auto &[key, path] : SettingsAssets::Fonts)
+    for (const auto &[key, path] : FontAssets::Fonts)
     {
         if (!assets.LoadFont(key, path))
         {
@@ -230,10 +233,8 @@ void SettingsScene::HandleEvent(const sf::Event &event)
     {
         if (event.key.code == sf::Keyboard::Escape)
         {
-            m_requestedScene = SceneID::MainMenu;
-            m_hasPendingTransition = true;
-
             CT_LOG_INFO("SettingsScene: Esc event handled.");
+            OnGoBack();
         }
     }
 }
@@ -297,9 +298,12 @@ void SettingsScene::CreateUI(SettingsPage page)
             break;
         }
 
-        case SettingsPage::KeyBindings:
+        case SettingsPage::Difficulty:
         {
-            CreateDifficultyControls();
+            if (m_includeDifficultyPage)
+            {
+                CreateDifficultyControls();
+            }
 
             break;
         }
@@ -344,7 +348,7 @@ void SettingsScene::CreateArrows(SettingsPage page)
 
     const sf::Vector2f arrowSize = {DEFAULT_ARROW_SIZE_PIXEL, DEFAULT_ARROW_SIZE_PIXEL};
 
-    if (page == SettingsPage::Audio || page == SettingsPage::KeyBindings)
+    if (page == SettingsPage::Audio || page == SettingsPage::Difficulty && m_includeDifficultyPage)
     {
         // LEFT ARROW
         const sf::Vector2f pos = {scaleMgr.ScaledReferenceX(DEFAULT_ARROW_LEFT_CENTER_PERCENT), centerY};
@@ -353,7 +357,7 @@ void SettingsScene::CreateArrows(SettingsPage page)
             UIFactory::Instance().CreateArrow(pos, arrowSize, UIAssets::UIArrowTextureKey, ArrowDirection::Left,
                                               [this, page]()
                                               {
-                                                  if (page == SettingsPage::KeyBindings)
+                                                  if (page == SettingsPage::Difficulty)
                                                   {
                                                       SwitchToPage(SettingsPage::Audio);
                                                   }
@@ -367,7 +371,7 @@ void SettingsScene::CreateArrows(SettingsPage page)
         UIManager::Instance().AddElement(leftArrow);
     }
 
-    if (page == SettingsPage::Audio || page == SettingsPage::Video)
+    if (page == SettingsPage::Audio && m_includeDifficultyPage || page == SettingsPage::Video)
     {
         // RIGHT ARROW
         const sf::Vector2f pos = {scaleMgr.ScaledReferenceX(DEFAULT_ARROW_RIGHT_CENTER_PERCENT), centerY};
@@ -378,7 +382,7 @@ void SettingsScene::CreateArrows(SettingsPage page)
                                               {
                                                   if (page == SettingsPage::Audio)
                                                   {
-                                                      SwitchToPage(SettingsPage::KeyBindings);
+                                                      SwitchToPage(SettingsPage::Difficulty);
                                                   }
 
                                                   else if (page == SettingsPage::Video)
@@ -452,9 +456,7 @@ void SettingsScene::CreateButtonControls()
                                                     [this]()
                                                     {
                                                         CT_LOG_INFO("SettingsScene: Go Back clicked.");
-                                                        *SettingsManager::Instance().GetSettings() = m_backupSettings;
-                                                        m_requestedScene = SceneID::MainMenu;
-                                                        m_hasPendingTransition = true;
+                                                        OnGoBack();
                                                     }));
 }
 
@@ -618,4 +620,21 @@ void SettingsScene::SwitchToPage(SettingsPage page)
 
     // Don't switch immediately — set for safe deferred swap
     m_pendingPageChange = page;
+}
+
+/// @brief Helper method for handling the returning logic from SettingsScene.
+void SettingsScene::OnGoBack()
+{
+    if (m_onReturn)
+    {
+        m_onReturn(); // e.g. returns to PauseScene
+    }
+
+    else
+    {
+        CT_LOG_INFO("SettingsScene: OnGoBack Event.");
+        *SettingsManager::Instance().GetSettings() = m_backupSettings;
+        m_requestedScene = SceneID::MainMenu;
+        m_hasPendingTransition = true;
+    }
 }

--- a/src/core/scenes/SettingsScene.h
+++ b/src/core/scenes/SettingsScene.h
@@ -18,6 +18,7 @@
 #include "UIElement.h"
 #include "UITextLabel.h"
 #include <SFML/Graphics.hpp>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -27,7 +28,7 @@ enum class SettingsPage
 {
     Audio,
     Video,
-    KeyBindings
+    Difficulty
 };
 
 // ============================================================================
@@ -44,7 +45,9 @@ enum class SettingsPage
 class SettingsScene : public Scene
 {
   public:
-    SettingsScene(std::shared_ptr<Settings> settings);
+    using ReturnCallback = std::function<void()>;
+
+    SettingsScene(std::shared_ptr<Settings> settings, bool includeDifficulty = true, ReturnCallback onReturn = nullptr);
     ~SettingsScene() = default;
 
     SettingsScene(const SettingsScene &) = delete;
@@ -76,18 +79,21 @@ class SettingsScene : public Scene
     void ShowToast(const std::string &message);
 
     void SwitchToPage(SettingsPage page);
+    void OnGoBack();
 
   private:
     std::shared_ptr<Settings> m_settings;
+    ReturnCallback m_onReturn;
     Settings m_backupSettings;
 
-    SettingsPage m_currentPage = SettingsPage::Audio;
+    SettingsPage m_currentPage;
     std::optional<SettingsPage> m_pendingPageChange;
     std::optional<std::string> m_pendingToast;
 
     std::shared_ptr<UIElement> m_applyButton;
-    SceneID m_requestedScene = SceneID::MainMenu;
+    SceneID m_requestedScene;
 
+    bool m_includeDifficultyPage = true;
     bool m_hasUnsavedChanges = false;
     bool m_showToast = false;
     float m_toastTimer = 0.f;

--- a/src/core/scenes/SplashScene.cpp
+++ b/src/core/scenes/SplashScene.cpp
@@ -59,7 +59,7 @@ void SplashScene::LoadRequiredAssets()
 {
     auto &assets = AssetManager::Instance();
 
-    for (const auto &[key, path] : SplashAssets::Fonts)
+    for (const auto &[key, path] : FontAssets::Fonts)
     {
         if (!assets.LoadFont(key, path))
         {

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 3
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 0
+#define CT_VERSION_PATCH 1
 
 /// @brief String representation for Chaos Theory version.
-#define CT_VERSION_STRING "1.3.0"
+#define CT_VERSION_STRING "1.3.1"


### PR DESCRIPTION
patched:  v1.3.1-Pause_Scene
	- Clean up around Assets namespace.
	- less magic constants!
	- LoadRequiredAssets() in scenes cleaned up a little better with new assets changes.
	- OnResume() function added to base Scene class. Not pure virtual, but useful for pausable scenes.
	- Changed SceneManager to use a Vector instead of Stack, as stack had limitations.
	- Updated SceneManager to include a new "DeferredPopScene" to prevent Pops in mid Update cycle, resulting in forbidden memory access and crashes.
	- SettingsScene added Function callback as optional in constructor. This signals that this is the PauseScene's settings scene. This scene has slight different behavior but is same class.