### PR TITLE
V1.4.7 build pch update

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(CT ${SRC_FILES})
 
 target_link_directories(CT PRIVATE ${PROJECT_SOURCE_DIR}/external/sfml/lib)
 
+target_precompile_headers(CT PRIVATE ${PROJECT_SOURCE_DIR}/src/core/pch.h)
+
 target_include_directories(CT PRIVATE
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/core

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,11 +3,9 @@
 file(GLOB_RECURSE CORE_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE CORE_HEADERS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 
-# for IDE projects
-source_group("Header Files" FILES ${CORE_HEADERS})
-source_group("Source Files" FILES ${CORE_SRC})
-
 add_library(core STATIC ${CORE_SRC})
+
+target_precompile_headers(core PRIVATE ${PROJECT_SOURCE_DIR}/src/core/pch.h)
 
 target_include_directories(core PUBLIC
     ${PROJECT_SOURCE_DIR}/src

--- a/src/core/pch.h
+++ b/src/core/pch.h
@@ -1,0 +1,39 @@
+// ============================================================================
+//  File        : pch.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-04-11
+//  Description : Precompiled header to speed up compilation
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+
+// ==== Standard Library Includes ====
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// ==== SFML ====
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <SFML/Window.hpp>
+
+// ==== External Libraries ====
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+// ==== Common Project Headers ====
+#include "Assets.h"
+#include "Macros.h"
+#include "ProjectilePresets.h"
+#include "Settings.h"
+#include "ShipPresets.h"
+#include "UIPresets.h"

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 4
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 6
+#define CT_VERSION_PATCH 7
 
 // Helper macros to convert numbers to strings
 #define CT_STRINGIFY(x) #x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,8 @@ target_include_directories(CT_tests PRIVATE
 # Link directories for SFML
 target_link_directories(CT_tests PRIVATE ${PROJECT_SOURCE_DIR}/external/sfml/lib)
 
+target_precompile_headers(CT_tests PRIVATE ${PROJECT_SOURCE_DIR}/src/core/pch.h)
+
 target_link_libraries(CT_tests
     PRIVATE
     core


### PR DESCRIPTION
patched:  v1.4.7-Build_PCH_Update
		- Add PreCompiled header with very common headers to reduce object build time.
		- Build speed increased by 5x minimum. 
		- Recognized a build restructure is a good option at this point, but not time spent efficiently. Future optimizations possible, with numerous refactors..