### PR TITLE
V1.5.6 crusader ship

### DIFF
--- a/src/core/AI/CrusaderBehavior.cpp
+++ b/src/core/AI/CrusaderBehavior.cpp
@@ -1,0 +1,284 @@
+// ============================================================================
+//  File        : CrusaderBehavior.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-08-24
+//  Description : Lines up to player's X, telegraphs (shake + red glow),
+//                then fires a lethal laser beam stream forward.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#include "CrusaderBehavior.h"
+#include "BaseShip.h"
+#include "ConfigurableGun.h"
+#include "GunPattern.h"
+#include "ProjectileManager.h"
+#include "ShipManager.h"
+#include "WindowManager.h"
+
+#include <cmath>
+
+/// @brief Constants that can be adjusted throughout the CrusaderBehavior.
+namespace
+{
+/// @brief Horizontal speed for aligning to player X.
+constexpr float ALIGN_SPEED_X = 220.f;
+
+/// @brief Constant downward drift while in Align phase.
+constexpr float DRIFT_SPEED_Y = 60.f;
+
+/// @brief Pixel tolerance in X for considering the ship aligned.
+constexpr float ALIGN_TOLERANCE_X = 8.f;
+
+/// @brief Telegraph duration before firing.
+constexpr float TELEGRAPH_TIME = 1.0f;
+
+/// @brief Horizontal shake amplitude during telegraph.
+constexpr float SHAKE_AMPLITUDE_X = 16.f;
+
+/// @brief Shake frequency.
+constexpr float SHAKE_FREQ = 25.f;
+
+/// @brief Beam firing window duration.
+constexpr float FIRE_TIME = 1.5f;
+
+/// @brief Minimum vertical offset (pixels) the player must be below before Crusader will telegraph/fire.
+constexpr float MIN_DIST_TO_FIRE = 24.f;
+
+/// @brief Cooldown after firing before Crusader can re-arm.
+constexpr float REARM_COOLDOWN = 5.0f;
+
+/// @brief Color for telegraph of the angry ship arming its laser.
+const sf::Color ARMING_LASER_COLOR = sf::Color(255, 80, 80);
+
+/// @brief Color for reverting back to normal after arming laser.
+const sf::Color NEUTRAL_COLOR = sf::Color::White;
+
+/// @brief Return direction of positive or negative based on x input.
+/// @param x Player coordinate location.
+/// @return Negative direction if player is to our left, right otherwise, or aligned == 0.
+inline float Sign(float x)
+{
+    return (x < 0.f) ? -1.f : (x > 0.f ? 1.f : 0.f);
+}
+
+/// @brief Returns the x-distance to the ship from us.
+/// @param ship Reference to the ship to compare against.
+/// @return float distance from the target ship.
+inline float DxToPlayer(const BaseShip &ship)
+{
+    auto player = ShipManager::Instance().GetPlayer();
+
+    if (!player)
+    {
+        return 0.f;
+    }
+
+    return player->GetPosition().x - ship.GetPosition().x;
+}
+
+/// @brief Returns the y-distance to the ship from us.
+/// @param ship Reference to the ship to compare against.
+/// @return float distance from the target ship.
+inline float DyToPlayer(const BaseShip &ship)
+{
+    auto player = ShipManager::Instance().GetPlayer();
+
+    if (!player)
+    {
+        return 0.f;
+    }
+
+    return player->GetPosition().y - ship.GetPosition().y;
+}
+
+} // namespace
+
+/// @brief Performs routine updates during a frame.
+/// @param ship The ship to perform the updpate on.
+/// @param dt Delta time since last update.
+void CrusaderBehavior::UpdateMovementLogic(BaseShip &ship, float dt)
+{
+    switch (m_phase)
+    {
+        case Phase::Align:
+        {
+            AlignToPlayerX(ship, dt);
+
+            // only proceed if player is below min dist theshold.
+            const float dx = std::fabs(DxToPlayer(ship));
+            const float dy = DyToPlayer(ship);
+            const bool alignedX = (dx <= ALIGN_TOLERANCE_X);
+            const bool playerBelow = (dy >= MIN_DIST_TO_FIRE);
+
+            if (alignedX && playerBelow)
+            {
+                m_phase = Phase::Telegraph;
+                m_phaseTimer = TELEGRAPH_TIME;
+                m_glowApplied = false;
+            }
+            break;
+        }
+        case Phase::Telegraph:
+            DoTelegraph(ship, dt);
+            break;
+        case Phase::Fire:
+            // slow ominous movement for effect.
+            ship.Move({0.f, DRIFT_SPEED_Y * 0.25f * dt});
+            break;
+        case Phase::Cooldown:
+            ship.Move({0.f, DRIFT_SPEED_Y * dt});
+            break;
+    }
+}
+
+/// @brief Performs routine gun logic during an update frame.
+/// @param ship Reference to the Ship to perform update for gun.
+/// @param dt Delta time since last update.
+void CrusaderBehavior::UpdateGunLogic(BaseShip &ship, float dt)
+{
+    switch (m_phase)
+    {
+        case Phase::Align:
+            break;
+
+        case Phase::Telegraph:
+            break;
+
+        case Phase::Fire:
+            DoFire(ship, dt);
+            break;
+
+        case Phase::Cooldown:
+            m_phaseTimer -= dt;
+
+            if (m_phaseTimer <= 0.f)
+            {
+                m_phase = Phase::Align;
+                m_firingPrimed = false;
+            }
+            break;
+    }
+}
+
+/// @brief Helper method to align Ship to player X coordinate location.
+/// @param ship Reference to ship to compare.
+/// @param dt Delta time since last update frame.
+void CrusaderBehavior::AlignToPlayerX(BaseShip &ship, float dt)
+{
+    ship.Move({0.f, DRIFT_SPEED_Y * dt});
+
+    auto player = ShipManager::Instance().GetPlayer();
+
+    if (!player)
+    {
+        return;
+    }
+
+    const float dx = DxToPlayer(ship);
+
+    if (std::fabs(dx) > ALIGN_TOLERANCE_X)
+    {
+        const float moveX = Sign(dx) * ALIGN_SPEED_X * dt;
+        ship.Move({moveX, 0.f});
+    }
+}
+
+/// @brief Helper method to perform animation and color choreograph before firing.
+/// @param ship Reference to ship to perform action on.
+/// @param dt Delta time since last update.
+void CrusaderBehavior::DoTelegraph(BaseShip &ship, float dt)
+{
+    // one-time red tint
+    if (!m_glowApplied)
+    {
+        ship.SetTint(ARMING_LASER_COLOR);
+        m_glowApplied = true;
+    }
+
+    // Capture anchor X once at the start of the telegraph window
+    if (!m_anchorCaptured)
+    {
+        m_shakeAnchorX = ship.GetPosition().x;
+        m_anchorCaptured = true;
+    }
+
+    m_phaseTimer -= dt;
+
+    const float elapsed = TELEGRAPH_TIME - std::max(0.f, m_phaseTimer);
+    const float currentX = ship.GetPosition().x;
+
+    const float shake = 2.f * PI * SHAKE_FREQ;
+    const float targetX = m_shakeAnchorX + std::sin(elapsed * shake) * SHAKE_AMPLITUDE_X;
+    const float dx = targetX - currentX;
+
+    ship.Move({dx, 0.f});
+
+    // tiny hover in y direction
+    ship.Move({0.f, DRIFT_SPEED_Y * 0.25f * dt});
+
+    if (m_phaseTimer <= 0.f)
+    {
+        m_anchorCaptured = false;
+        m_phase = Phase::Fire;
+        m_phaseTimer = FIRE_TIME;
+        m_firingPrimed = false;
+    }
+}
+
+/// @brief Helper method to prime the ships gun for the firing phase.
+/// @param ship The ship which will perform the action.
+void CrusaderBehavior::BeginFire(BaseShip &ship)
+{
+    auto *gun = dynamic_cast<ConfigurableGun *>(ship.GetGun());
+
+    if (!gun)
+    {
+        return;
+    }
+
+    gun->SetPattern(GunPattern::LaserBeam);
+
+    // Crank up the stats so the stream feels "instant & fatal".
+    gun->UpgradeFireRate(.05f);
+    gun->UpgradeVelocity(1000.f);
+
+    m_firingPrimed = true;
+}
+
+/// @brief Perform the actions for Firing a primed laser stream.
+/// @param ship The ship which will perform the action.
+/// @param dt Delta time since last update.
+void CrusaderBehavior::DoFire(BaseShip &ship, float dt)
+{
+    if (!m_firingPrimed)
+    {
+        BeginFire(ship);
+    }
+
+    auto *gun = ship.GetGun();
+    if (gun)
+    {
+        gun->SetOwnerPosition(ship.GetPosition());
+        gun->Update(dt);
+
+        if (auto proj = gun->TryFire())
+        {
+            ProjectileManager::Instance().AddProjectile(proj);
+        }
+    }
+
+    m_phaseTimer -= dt;
+
+    if (m_phaseTimer <= 0.f)
+    {
+        ship.SetTint(NEUTRAL_COLOR);
+
+        m_phase = Phase::Cooldown;
+        m_phaseTimer = REARM_COOLDOWN;
+        m_firingPrimed = false;
+        m_anchorCaptured = false;
+    }
+}

--- a/src/core/AI/CrusaderBehavior.h
+++ b/src/core/AI/CrusaderBehavior.h
@@ -1,0 +1,63 @@
+// ============================================================================
+//  File        : CrusaderBehavior.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-08-24
+//  Description : Lines up to player's X, telegraphs (shake + red glow),
+//                then fires a lethal laser beam stream forward.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+
+#include "IBehavior.h"
+#include <SFML/Graphics.hpp>
+
+// ============================================================================
+//  Class       : CrusaderBehavior
+//  Purpose     : Implements IBehavior interface for a Crusader behavior:
+//                Moves in x direction towards player, locks on, and changes
+//                mode to fire a deadly laser beam stream. Then reverts to
+//                cooldown and attempt to lock on again if able to.
+//
+//  Responsibilities:
+//      - Update logic for movement.
+//      - Update logic for gun.
+//
+// ============================================================================
+class CrusaderBehavior : public IBehavior
+{
+  public:
+    ~CrusaderBehavior() override = default;
+
+  protected:
+    // IBehavior hooks
+    void UpdateMovementLogic(BaseShip &ship, float dt) override;
+    void UpdateGunLogic(BaseShip &ship, float dt) override;
+
+  private:
+    enum class Phase
+    {
+        Align,
+        Telegraph,
+        Fire,
+        Cooldown
+    };
+
+    void AlignToPlayerX(BaseShip &ship, float dt);
+    void DoTelegraph(BaseShip &ship, float dt);
+    void BeginFire(BaseShip &ship);
+    void DoFire(BaseShip &ship, float dt);
+
+  private:
+    Phase m_phase = Phase::Align;
+
+    float m_phaseTimer = 0.f;
+    float m_shakeAnchorX = 0.f;
+
+    bool m_firingPrimed = false;
+    bool m_glowApplied = false;
+    bool m_anchorCaptured = false;
+};

--- a/src/core/AI/StrafeAndShootBehavior.cpp
+++ b/src/core/AI/StrafeAndShootBehavior.cpp
@@ -15,6 +15,32 @@
 #include "WindowManager.h"
 #include <cmath>
 
+/// @brief Constants that can be adjusted throughout the StrafeAndShootBehavior.
+namespace
+{
+/// @brief Configurable time between random horizontal direction changes.
+constexpr float DIRECTION_CHANGE_INTERVAL = 1.0f;
+
+/// @brief Configurable multiplier to reduce horizontal strafe speed.
+constexpr float INTERNAL_X_DAMPENER = 0.5f;
+
+/// @brief Configurable multiplier to reduce vertical speed.
+constexpr float INTERNAL_Y_DAMPENER = .25f;
+
+/// @brief Configurable seconds to wait before the first shot.
+constexpr float INITIAL_HOLD_TIME = 1.0f;
+} // namespace
+
+/// @brief Simple constructor for establishing configurables used during update behaviors.
+StrafeAndShootBehavior::StrafeAndShootBehavior()
+{
+    m_directionChangeCooldown = DIRECTION_CHANGE_INTERVAL;
+    m_initialHoldTime = INITIAL_HOLD_TIME;
+
+    std::uniform_int_distribution<int> dist(0, 1);
+    m_currentDirX = (dist(m_rng) == 0) ? -1.f : 1.f;
+}
+
 /// @brief Deterministic state management of movement for StrafeAndShootBehavior class.
 /// @param ship Pointer to the Ship which inherits this interface.
 /// @param dt Delta time since last update.
@@ -29,12 +55,12 @@ void StrafeAndShootBehavior::UpdateMovementLogic(BaseShip &ship, float dt)
         // RNG 1: positive x direction
         std::uniform_int_distribution<int> dist(0, 1);
         m_currentDirX = (dist(m_rng) == 0) ? -1.f : 1.f;
-        m_directionChangeCooldown = sDirectionChangeInterval;
+        m_directionChangeCooldown = DIRECTION_CHANGE_INTERVAL;
     }
 
     // 2) Strafe X + slow descent Y
     const sf::Vector2f speed = ship.GetSpeed();
-    sf::Vector2f delta{m_currentDirX * speed.x * sInternalXDampener * dt, (speed.y / sInternalYDampener) * dt};
+    sf::Vector2f delta{m_currentDirX * speed.x * INTERNAL_X_DAMPENER * dt, (speed.y * INTERNAL_Y_DAMPENER) * dt};
     ship.Move(delta);
 
     // 3) Clamp horizontally to screen bounds

--- a/src/core/AI/StrafeAndShootBehavior.h
+++ b/src/core/AI/StrafeAndShootBehavior.h
@@ -29,6 +29,7 @@
 class StrafeAndShootBehavior : public IBehavior
 {
   public:
+    StrafeAndShootBehavior();
     ~StrafeAndShootBehavior() override = default;
 
   protected:
@@ -36,17 +37,10 @@ class StrafeAndShootBehavior : public IBehavior
     void UpdateMovementLogic(BaseShip &ship, float dt) override;
     void UpdateGunLogic(BaseShip &ship, float dt) override;
 
-  protected:
-    // Per-behavior constants (tweak here if needed; or make setters later)
-    static constexpr float sDirectionChangeInterval = 1.0f; // seconds
-    static constexpr float sInternalXDampener = 0.5f;       // slows horizontal strafe
-    static constexpr float sInternalYDampener = 4.0f;       // slows descent
-    static constexpr float sInitialHoldTime = 1.0f;         // delay before first shot
-
-    // Behavior-owned state (ships inherit this, so each instance gets its own copy)
-    float m_directionChangeCooldown = sDirectionChangeInterval;
-    float m_currentDirX = 1.f;
-    float m_initialHoldTime = sInitialHoldTime;
-
+  private:
     std::mt19937 m_rng{std::random_device{}()};
+
+    float m_directionChangeCooldown = 0.f;
+    float m_currentDirX = 0.f;
+    float m_initialHoldTime = 0.f;
 };

--- a/src/core/common/Assets.h
+++ b/src/core/common/Assets.h
@@ -526,6 +526,7 @@ static const std::unordered_map<std::string, std::string> Sprites = {
     {"RocketProjectile", "assets/sprites/projectiles/RocketProjectile.png"},
     {"AlienShip", "assets/sprites/enemies/AlienShip.png"},
     {"BerserkerShip", "assets/sprites/enemies/BerserkerShip.png"},
+    {"CrusaderShip", "assets/sprites/enemies/CrusaderShip.png"},
     {"AstronautSpeakerBlack", "assets/sprites/players/AstronautSpeakerBlack.png"},
     {"AstronautSpeakerBlue", "assets/sprites/players/AstronautSpeakerBlue.png"},
     {"AstronautSpeakerGold", "assets/sprites/players/AstronautSpeakerGold.png"},

--- a/src/core/managers/ShipManager.cpp
+++ b/src/core/managers/ShipManager.cpp
@@ -95,6 +95,14 @@ void ShipManager::SpawnBerserkerEnemy(const sf::Vector2f &pos)
     m_enemies.push_back(enemy);
 }
 
+/// @brief Creates a CrusaderShip object to be managed by ShipManager.
+/// @param pos Coordinate position to spawn at.
+void ShipManager::SpawnCrusaderEnemy(const sf::Vector2f &pos)
+{
+    auto enemy = ShipFactory::Instance().CreateCrusaderShip(pos, Allegiance::Enemy);
+    m_enemies.push_back(enemy);
+}
+
 /// @brief Returns a reference to the PlayerShip.
 /// @return Safe pointer to m_player.
 std::shared_ptr<PlayerShip> ShipManager::GetPlayer() const

--- a/src/core/managers/ShipManager.h
+++ b/src/core/managers/ShipManager.h
@@ -41,6 +41,7 @@ class ShipManager
     void SpawnBasicEnemy(const sf::Vector2f &pos);
     void SpawnAlienEnemy(const sf::Vector2f &pos);
     void SpawnBerserkerEnemy(const sf::Vector2f &pos);
+    void SpawnCrusaderEnemy(const sf::Vector2f &pos);
 
     std::shared_ptr<PlayerShip> GetPlayer() const;
     const std::vector<std::shared_ptr<BaseShip>> &GetEnemies() const;

--- a/src/core/scenes/SandBoxScene.cpp
+++ b/src/core/scenes/SandBoxScene.cpp
@@ -332,9 +332,10 @@ void SandBoxScene::SetupSceneComponents()
     MockHUDPanel(HUD_MOCK_BOOL);
     MockIconComponents(true);
     MockChatBox(false);
-    MockBasicShipTest(true);
-    MockAlienShipTest(true);
+    MockBasicShipTest(false);
+    MockAlienShipTest(false);
     MockBerserkerShipTest(false);
+    MockCrusaderShipTest(true);
 }
 
 /// @brief Helper method to create the Title string entity for this scene.
@@ -596,9 +597,22 @@ void SandBoxScene::MockBerserkerShipTest(const bool enabled)
 
     const auto winSize = WindowManager::Instance().GetWindow().getSize();
 
-    // TODO: make SpawnBerserkerEnemy and revisit.
     ShipManager::Instance().SpawnBerserkerEnemy({winSize.x * .15f, 25.f});
     ShipManager::Instance().SpawnBerserkerEnemy({winSize.x * .70f, 25.f});
+}
+
+/// @brief Mock enemy units to spawn. Specifically call for CrusaderShip.
+/// @param enabled is enabled or not
+void SandBoxScene::MockCrusaderShipTest(const bool enabled)
+{
+    if (!enabled)
+    {
+        return;
+    }
+
+    const auto winSize = WindowManager::Instance().GetWindow().getSize();
+
+    ShipManager::Instance().SpawnCrusaderEnemy({winSize.x * .30f, 25.f});
 }
 
 /// @brief Mock player test

--- a/src/core/scenes/SandBoxScene.h
+++ b/src/core/scenes/SandBoxScene.h
@@ -71,6 +71,7 @@ class SandBoxScene final : public Scene
     void MockBasicShipTest(const bool enabled);
     void MockAlienShipTest(const bool enabled);
     void MockBerserkerShipTest(const bool enabled);
+    void MockCrusaderShipTest(const bool enabled);
 
     void MockPlayerUnit(const bool enabled);
 

--- a/src/core/ships/BaseShip.cpp
+++ b/src/core/ships/BaseShip.cpp
@@ -43,6 +43,13 @@ void BaseShip::Draw(sf::RenderTarget &target)
     }
 }
 
+/// @brief Exposes access to set the color for this BaseShip.
+/// @param color Color to set sprite with.
+void BaseShip::SetTint(const sf::Color &color)
+{
+    m_sprite.setColor(color);
+}
+
 /// @brief Return the health of the ship.
 /// @return m_health.
 int BaseShip::GetHealth() const

--- a/src/core/ships/BaseShip.h
+++ b/src/core/ships/BaseShip.h
@@ -50,6 +50,7 @@ class BaseShip : public BaseCollidable
 
   public:
     virtual void Draw(sf::RenderTarget &target);
+    virtual void SetTint(const sf::Color &color);
 
     virtual int GetHealth() const;
     virtual void SetHealth(const int maxHealth);

--- a/src/core/ships/CrusaderShip.cpp
+++ b/src/core/ships/CrusaderShip.cpp
@@ -1,0 +1,96 @@
+// ============================================================================
+//  File        : CrusaderShip.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-08-24
+//  Description : A telegraphed laser attacker. Aligns to player's X, shakes,
+//                glows red, then fires a lethal beam stream.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#include "CrusaderShip.h"
+#include "AssetManager.h"
+#include "Assets.h"
+#include "EnemyGun.h"
+#include "Macros.h"
+#include "WindowManager.h"
+
+/// @brief Constants that can be adjusted throughout the CrusaderShip.
+namespace
+{
+/// @brief Base health for the CrusaderShip.
+constexpr int CRUSADER_BASE_HEALTH = 45;
+
+/// @brief Beam defaults, damage IS important for ship.
+constexpr float CRUSADER_BEAM_DAMAGE = 20.f;
+
+/// @brief Beam defaults, irrelevant once behavior upgrades.
+constexpr float CRUSADER_BEAM_FIRERATE = 2.0f;
+
+/// @brief Beam defaults, irrelevant once behavior upgrades.
+constexpr float CRUSADER_BEAM_SPEED = 800.f;
+
+/// @brief Configurable general drift magnitude.
+const sf::Vector2f CRUSADER_BASE_SPEED = {0.f, 120.f};
+
+/// @brief Configurable color for laser beam.
+const sf::Color CRUSADER_BEAM_COLOR = sf::Color(255, 80, 80);
+} // namespace
+
+/// @brief Constructs a CrusaderShip
+/// @param startPos Starting position.
+/// @param allegiance Allegiance.
+CrusaderShip::CrusaderShip(const sf::Vector2f &startPos, Allegiance allegiance)
+{
+    auto tex = AssetManager::Instance().GetTexture(SpriteAssets::EnemyAssets::CrusaderShipSpriteKey);
+
+    if (!tex)
+    {
+        CT_LOG_ERROR("CrusaderShip texture not found: EnemyAssets::CrusaderShipSpriteKey");
+
+        return;
+    }
+
+    m_sprite.setTexture(*tex);
+    m_sprite.setPosition(startPos);
+    m_sprite.setOrigin(tex->getSize().x * 0.5f, tex->getSize().y * 0.5f);
+    m_allegiance = allegiance;
+
+    m_health = m_maxHealth = ScaleHealthToDifficulty(CRUSADER_BASE_HEALTH);
+    m_speed = ScaleSpeedToDifficulty(CRUSADER_BASE_SPEED);
+    SetSpriteColorFromDifficulty(m_sprite);
+
+    InitializeGunStats();
+}
+
+/// @brief Performs routine update during a frame.
+/// @param dt Delta time since last update.
+void CrusaderShip::Update(float dt)
+{
+    if (!m_alive)
+    {
+        return;
+    }
+
+    UpdateBehavior(*this, dt);
+    CullIfOffscreen();
+}
+
+/// @brief Initializes the CrusaderShip with gun statistics.
+void CrusaderShip::InitializeGunStats()
+{
+    // Base gun for beam; behavior will swap to laser stream and crank stats at fire time.
+    m_gunStats.fireRate = CRUSADER_BEAM_FIRERATE;
+    m_gunStats.damage = CRUSADER_BEAM_DAMAGE;
+    m_gunStats.speed = CRUSADER_BEAM_SPEED;
+    m_gunStats.tint = CRUSADER_BEAM_COLOR;
+    m_gunStats.homing = false;
+
+    m_gun = std::make_unique<EnemyGun>(m_gunStats);
+
+    const sf::Vector2f spriteSize(static_cast<float>(m_sprite.getTexture()->getSize().x),
+                                  static_cast<float>(m_sprite.getTexture()->getSize().y));
+    m_gun->SetAllegiance(Allegiance::Enemy, spriteSize);
+}

--- a/src/core/ships/CrusaderShip.h
+++ b/src/core/ships/CrusaderShip.h
@@ -1,0 +1,47 @@
+// ============================================================================
+//  File        : CrusaderShip.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-08-24
+//  Description : A telegraphed laser attacker. Aligns to player's X, shakes,
+//                glows red, then fires a lethal beam stream.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+#include "BaseShip.h"
+#include "CrusaderBehavior.h"
+#include "ShipStatsScaling.h"
+
+// ============================================================================
+//  Class       : CrusaderShip
+//  Purpose     : An aggressor spaceship that tracks the players x position
+//                and upon lining up, begins to charge a laser beam stream.
+//                This stream is extra fast, and fires at a deadly rate.
+//
+//  Responsibilities:
+//      - Scale upon construction based on game difficulty and window size.
+//      - Update position and aliveness for this spaceship.
+//
+// ============================================================================
+class CrusaderShip : public BaseShip, public ShipStatsScaling, public CrusaderBehavior
+{
+  public:
+    CrusaderShip(const sf::Vector2f &startPos, Allegiance allegiance);
+    ~CrusaderShip() override = default;
+
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    CrusaderShip(const CrusaderShip &) = delete;
+    CrusaderShip &operator=(const CrusaderShip &) = delete;
+
+    CrusaderShip(CrusaderShip &&) = delete;
+    CrusaderShip &operator=(CrusaderShip &&) = delete;
+
+  public:
+    void Update(float dt) override;
+
+  private:
+    void InitializeGunStats() override;
+};

--- a/src/core/ships/ShipFactory.cpp
+++ b/src/core/ships/ShipFactory.cpp
@@ -15,6 +15,7 @@
 #include "Assets.h"
 #include "BasicShip.h"
 #include "BerserkerShip.h"
+#include "CrusaderShip.h"
 #include "Macros.h"
 #include "PlayerShip.h"
 #include "ResolutionScaleManager.h"
@@ -141,6 +142,37 @@ std::shared_ptr<BaseShip> ShipFactory::CreateBerserkerShip(const sf::Vector2f &p
     else
     {
         CT_LOG_ERROR("ShipFactory-BerserkerShip texture not found during creation!");
+    }
+
+    return ship;
+}
+
+/// @brief Creates a CrusaderShip, scaled appropriately with the window resolution.
+/// @param pos Starting position to emplace ship at.
+/// @param allegiance Allegiance to employ ship with.
+/// @return Safe pointer to a CrusaderShip, compatible with the BaseShip base class.
+std::shared_ptr<BaseShip> ShipFactory::CreateCrusaderShip(const sf::Vector2f &pos, Allegiance allegiance)
+{
+    auto ship = std::make_shared<CrusaderShip>(pos, allegiance);
+
+    // Setup resolution-based scaling
+    auto tex = AssetManager::Instance().GetTexture(SpriteAssets::EnemyAssets::CrusaderShipSpriteKey);
+
+    if (tex)
+    {
+        // resolution for CrusaderShip DOES matter, because it is 32 x 64 pixel.
+        float textureWidth = static_cast<float>(tex->getSize().x);
+        float textureHeight = static_cast<float>(tex->getSize().y);
+        float scaledWidth = ResolutionScaleManager::Instance().ScaleX(textureWidth);
+        float scaledHeight = ResolutionScaleManager::Instance().ScaleY(textureHeight);
+        float scaleFactorX = scaledWidth / textureWidth;
+        float scaleFactorY = scaledHeight / textureHeight;
+        ship->SetScale(scaleFactorX, scaleFactorY);
+    }
+
+    else
+    {
+        CT_LOG_ERROR("ShipFactory-CrusaderShip texture not found during creation!");
     }
 
     return ship;

--- a/src/core/ships/ShipFactory.h
+++ b/src/core/ships/ShipFactory.h
@@ -31,6 +31,7 @@ class ShipFactory
     std::shared_ptr<BaseShip> CreateBasicShip(const sf::Vector2f &pos, Allegiance allegiance);
     std::shared_ptr<BaseShip> CreateAlienShip(const sf::Vector2f &pos, Allegiance allegiance);
     std::shared_ptr<BaseShip> CreateBerserkerShip(const sf::Vector2f &pos, Allegiance allegiance);
+    std::shared_ptr<BaseShip> CreateCrusaderShip(const sf::Vector2f &pos, Allegiance allegiance);
 
   private:
     ShipFactory() = default;

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 5
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 5
+#define CT_VERSION_PATCH 6
 
 // Helper macros to convert numbers to strings
 #define CT_STRINGIFY(x) #x


### PR DESCRIPTION
patched:  v1.5.6-Crusader
                - Added CrusaderShip to ChaosTheory
		- Create behavior for Crusader
		- Create CrusaderShip
		- Add in factory hook
		- Add in ShipManager hook
		- Update Sandbox to mock and inspect
		- Added SetTint to BaseShip, allows access to color ships for effect
		- Moved constants into the cpp file for StrafeAndShootBehavior.