### PR TITLE
V1.5.7 grunt ship

### DIFF
--- a/src/core/AI/BerserkerBehavior.h
+++ b/src/core/AI/BerserkerBehavior.h
@@ -30,17 +30,25 @@
 class BerserkerBehavior : public IBehavior
 {
   public:
+    BerserkerBehavior() = default;
     ~BerserkerBehavior() override = default;
 
-    void SetSpawnTargetSnapshot(const sf::Vector2f &playerPos);
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    BerserkerBehavior(const BerserkerBehavior &) = delete;
+    BerserkerBehavior &operator=(const BerserkerBehavior &) = delete;
 
-    bool HasSnapshot() const;
-    void ClearSnapshot();
+    BerserkerBehavior(BerserkerBehavior &&) = delete;
+    BerserkerBehavior &operator=(BerserkerBehavior &&) = delete;
 
   protected:
     // IBehavior hooks
     void UpdateMovementLogic(BaseShip &ship, float dt) override;
     void UpdateGunLogic(BaseShip &ship, float dt) override;
+
+  public:
+    void SetSpawnTargetSnapshot(const sf::Vector2f &playerPos);
+    bool HasSnapshot() const;
+    void ClearSnapshot();
 
   private:
     void EnsureDirectionInitialized(BaseShip &ship);

--- a/src/core/AI/CrusaderBehavior.cpp
+++ b/src/core/AI/CrusaderBehavior.cpp
@@ -214,6 +214,7 @@ void CrusaderBehavior::DoTelegraph(BaseShip &ship, float dt)
     const float targetX = m_shakeAnchorX + std::sin(elapsed * shake) * SHAKE_AMPLITUDE_X;
     const float dx = targetX - currentX;
 
+    // move direction for random oscillations
     ship.Move({dx, 0.f});
 
     // tiny hover in y direction
@@ -239,9 +240,8 @@ void CrusaderBehavior::BeginFire(BaseShip &ship)
         return;
     }
 
+    // Crank up the stats so the stream feels instant and fatal.
     gun->SetPattern(GunPattern::LaserBeam);
-
-    // Crank up the stats so the stream feels "instant & fatal".
     gun->UpgradeFireRate(.05f);
     gun->UpgradeVelocity(1000.f);
 
@@ -259,6 +259,7 @@ void CrusaderBehavior::DoFire(BaseShip &ship, float dt)
     }
 
     auto *gun = ship.GetGun();
+
     if (gun)
     {
         gun->SetOwnerPosition(ship.GetPosition());
@@ -275,7 +276,6 @@ void CrusaderBehavior::DoFire(BaseShip &ship, float dt)
     if (m_phaseTimer <= 0.f)
     {
         ship.SetTint(NEUTRAL_COLOR);
-
         m_phase = Phase::Cooldown;
         m_phaseTimer = REARM_COOLDOWN;
         m_firingPrimed = false;

--- a/src/core/AI/CrusaderBehavior.h
+++ b/src/core/AI/CrusaderBehavior.h
@@ -30,7 +30,15 @@
 class CrusaderBehavior : public IBehavior
 {
   public:
+    CrusaderBehavior() = default;
     ~CrusaderBehavior() override = default;
+
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    CrusaderBehavior(const CrusaderBehavior &) = delete;
+    CrusaderBehavior &operator=(const CrusaderBehavior &) = delete;
+
+    CrusaderBehavior(CrusaderBehavior &&) = delete;
+    CrusaderBehavior &operator=(CrusaderBehavior &&) = delete;
 
   protected:
     // IBehavior hooks

--- a/src/core/AI/DodgeAndAimBehavior.cpp
+++ b/src/core/AI/DodgeAndAimBehavior.cpp
@@ -1,0 +1,232 @@
+// ============================================================================
+//  File        : DodgeAndAimBehavior.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-09-05
+//  Description : Short-hop dodge to a nearby X/Y, snapshot-aim at player's
+//                current location, fire a single projectile, then drift & cool.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#include "DodgeAndAimBehavior.h"
+#include "BaseShip.h"
+#include "ConfigurableGun.h"
+#include "Macros.h"
+#include "ProjectileManager.h"
+#include "ShipManager.h"
+#include "WindowManager.h"
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+/// @brief Constants that can be adjusted throughout the DodgeAndAimBehavior.
+namespace
+{
+/// @brief Horizontal/vertical hop speed toward the short-distance dodge target.
+static constexpr float HOP_SPEED = 260.f;
+
+/// @brief Constant vertical drift while not explicitly moving to target.
+static constexpr float DRIFT_SPEED_Y = 80.f;
+
+/// @brief Distance tolerance to consider the target reached.
+static constexpr float TARGET_TOLERANCE = 6.f;
+
+/// @brief Target within this min x distance from current pos for a Dodge hop.
+static constexpr float HOP_MIN_X = 40.f;
+
+/// @brief Target within this max x distance from current pos for a Dodge hop.
+static constexpr float HOP_MAX_X = 140.f;
+
+/// @brief Target within this min y distance from current pos for a Dodge hop.
+static constexpr float HOP_MIN_Y = 20.f;
+
+/// @brief Target within this max y distance from current pos for a Dodge hop.
+static constexpr float HOP_MAX_Y = 60.f;
+
+/// @brief Time constraint before firing during the Aim and Fire phase.
+static constexpr float AIM_WINDUP = 0.15f;
+
+/// @brief Cooldown after firing before another cycle can begin.
+static constexpr float COOLDOWN_TIME = 2.0f;
+
+/// @brief Clamp margins so target stays on screen.
+static constexpr float SCREEN_MARGIN = 16.f;
+
+/// @brief Bullet default speed.
+static constexpr float BULLET_SPEED = 420.f;
+
+/// @brief Bullet default damage.
+static constexpr float BULLET_DAMAGE = 8.f;
+
+/// @brief Random helper. Generates a range between lo and hi inclusive.
+/// @param low bottom end random.
+/// @param high top end random.
+/// @return random inbetween lo and hi
+inline float RandRange(float low, float high)
+{
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    std::uniform_real_distribution<float> dist(low, high);
+
+    return dist(rng);
+}
+} // namespace
+
+/// @brief Performs routine updates during a frame.
+/// @param ship The ship to perform the updpate on.
+/// @param dt Delta time since last update.
+void DodgeAndAimBehavior::UpdateMovementLogic(BaseShip &ship, float dt)
+{
+    switch (m_phase)
+    {
+        case Phase::ChooseTarget:
+        {
+            PickNearbyTarget(ship);
+            m_phase = Phase::MoveToTarget;
+
+            break;
+        }
+
+        case Phase::MoveToTarget:
+        {
+            MoveTowardTarget(ship, dt);
+
+            // Small constant downward drift so it still advances the screen.
+            ship.Move({0.f, DRIFT_SPEED_Y * 0.35f * dt});
+
+            const sf::Vector2f dx = m_target - ship.GetPosition();
+
+            if (std::abs(dx.x) <= TARGET_TOLERANCE && std::abs(dx.y) <= TARGET_TOLERANCE)
+            {
+                // Snapshot player's current position at aim time.
+                if (auto player = ShipManager::Instance().GetPlayer())
+                {
+                    m_snapshotPlayerPos = player->GetPosition();
+                }
+
+                else
+                {
+                    m_snapshotPlayerPos = ship.GetPosition() + sf::Vector2f{0.f, 32.f};
+                }
+
+                m_phaseTimer = AIM_WINDUP;
+                m_fired = false;
+                m_phase = Phase::AimAndFire;
+            }
+
+            break;
+        }
+
+        case Phase::AimAndFire:
+        {
+            // Hover slightly while aiming.
+            ship.Move({0.f, DRIFT_SPEED_Y * 0.15f * dt});
+
+            m_phaseTimer -= dt;
+
+            if (m_phaseTimer <= 0.f && !m_fired)
+            {
+                FireAimedShot(ship);
+                m_fired = true;
+                m_phase = Phase::Cooldown;
+                m_phaseTimer = COOLDOWN_TIME;
+            }
+
+            break;
+        }
+
+        case Phase::Cooldown:
+        {
+            // Drift downward during cooldown.
+            ship.Move({0.f, DRIFT_SPEED_Y * dt});
+
+            m_phaseTimer -= dt;
+
+            if (m_phaseTimer <= 0.f)
+            {
+                m_phase = Phase::ChooseTarget;
+                m_hasTarget = false;
+            }
+
+            break;
+        }
+    }
+}
+
+/// @brief Performs routine gun logic during an update frame.
+/// @param ship Reference to Ship.
+/// @param dt delta time since last update.
+void DodgeAndAimBehavior::UpdateGunLogic(BaseShip &ship, float dt)
+{
+    if (auto *gun = ship.GetGun())
+    {
+        gun->SetOwnerPosition(ship.GetPosition());
+        gun->Update(dt);
+    }
+}
+
+/// @brief Helper function to locate a nearby X/Y coordinate to use as the Hop logic for Dodge and Aim.
+/// @param ship Reference to the ship.
+void DodgeAndAimBehavior::PickNearbyTarget(const BaseShip &ship)
+{
+    const auto &window = WindowManager::Instance().GetWindow();
+    const auto winSize = window.getSize();
+
+    const sf::Vector2f pos = ship.GetPosition();
+
+    const float dx = RandRange(HOP_MIN_X, HOP_MAX_X) * (RandRange(0.f, 1.f) < 0.5f ? -1.f : 1.f);
+    const float dy = RandRange(HOP_MIN_Y, HOP_MAX_Y) * (RandRange(0.f, 1.f) < 0.5f ? -1.f : 1.f);
+
+    sf::Vector2f candidate = {pos.x + dx, pos.y + dy};
+
+    // Clamp within the screen bounds with a small margin.
+    candidate.x = std::clamp(candidate.x, SCREEN_MARGIN, static_cast<float>(winSize.x) - SCREEN_MARGIN);
+    candidate.y = std::clamp(candidate.y, SCREEN_MARGIN, static_cast<float>(winSize.y) - SCREEN_MARGIN);
+
+    m_target = candidate;
+    m_hasTarget = true;
+}
+
+/// @brief Helpepr function to provide step movements for the ship during the Dodge portion of logic.
+/// @param ship Reference to the ship.
+/// @param dt delta time since last update.
+void DodgeAndAimBehavior::MoveTowardTarget(BaseShip &ship, float dt)
+{
+    if (!m_hasTarget)
+    {
+        return;
+    }
+
+    const sf::Vector2f p = ship.GetPosition();
+    const sf::Vector2f dp = m_target - p;
+
+    // Stop if very close
+    if (std::abs(dp.x) <= TARGET_TOLERANCE && std::abs(dp.y) <= TARGET_TOLERANCE)
+    {
+        return;
+    }
+
+    const sf::Vector2f dir = CT_MATH::Normalize(dp);
+    const sf::Vector2f vel = {dir.x * HOP_SPEED, dir.y * HOP_SPEED};
+
+    ship.Move({vel.x * dt, vel.y * dt});
+}
+
+/// @brief Fire a single projectile at the target location.
+/// @param ship Reference to the ship that is firing.
+void DodgeAndAimBehavior::FireAimedShot(BaseShip &ship)
+{
+    if (auto *cfg = dynamic_cast<ConfigurableGun *>(ship.GetGun()))
+    {
+        cfg->SetOwnerPosition(ship.GetPosition());
+        cfg->SetPattern(GunPattern::DirectedShot);
+
+        if (auto proj = cfg->TryFireTowards(m_snapshotPlayerPos))
+        {
+            ProjectileManager::Instance().AddProjectile(proj);
+
+            return;
+        }
+    }
+}

--- a/src/core/AI/DodgeAndAimBehavior.h
+++ b/src/core/AI/DodgeAndAimBehavior.h
@@ -1,0 +1,70 @@
+// ============================================================================
+//  File        : DodgeAndAimBehavior.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-09-05
+//  Description : Short hop dodge to a nearby X/Y, snapshot-aim at players
+//                current location, fire a single projectile, then drift & cool.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+
+#include "IBehavior.h"
+#include <SFML/Graphics.hpp>
+
+// ============================================================================
+//  Class       : DodgeAndAimBehavior
+//  Purpose     : Implements IBehavior interface for a DodgeAndAim behavior:
+//                Dodges to a nearby X/Y, then fires a single aimed shot at
+//                the player's current position, then cools down while
+//                drifting downward.
+//
+//  Responsibilities:
+//      - Update logic for movement.
+//      - Update logic for gun.
+//
+// ============================================================================
+class DodgeAndAimBehavior : public IBehavior
+{
+  public:
+    DodgeAndAimBehavior() = default;
+    ~DodgeAndAimBehavior() override = default;
+
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    DodgeAndAimBehavior(const DodgeAndAimBehavior &) = delete;
+    DodgeAndAimBehavior &operator=(const DodgeAndAimBehavior &) = delete;
+
+    DodgeAndAimBehavior(DodgeAndAimBehavior &&) = delete;
+    DodgeAndAimBehavior &operator=(DodgeAndAimBehavior &&) = delete;
+
+  protected:
+    // IBehavior hooks
+    void UpdateMovementLogic(BaseShip &ship, float dt) override;
+    void UpdateGunLogic(BaseShip &ship, float dt) override;
+
+  private:
+    enum class Phase
+    {
+        ChooseTarget,
+        MoveToTarget,
+        AimAndFire,
+        Cooldown
+    };
+
+    void PickNearbyTarget(const BaseShip &ship);
+    void MoveTowardTarget(BaseShip &ship, float dt);
+    void FireAimedShot(BaseShip &ship);
+
+  private:
+    Phase m_phase = Phase::ChooseTarget;
+    sf::Vector2f m_target{};
+    sf::Vector2f m_snapshotPlayerPos{};
+
+    float m_phaseTimer = 0.f;
+
+    bool m_hasTarget = false;
+    bool m_fired = false;
+};

--- a/src/core/AI/DrifterBehavior.h
+++ b/src/core/AI/DrifterBehavior.h
@@ -29,7 +29,15 @@
 class DrifterBehavior : public IBehavior
 {
   public:
+    DrifterBehavior() = default;
     ~DrifterBehavior() override = default;
+
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    DrifterBehavior(const DrifterBehavior &) = delete;
+    DrifterBehavior &operator=(const DrifterBehavior &) = delete;
+
+    DrifterBehavior(DrifterBehavior &&) = delete;
+    DrifterBehavior &operator=(DrifterBehavior &&) = delete;
 
   protected:
     void UpdateMovementLogic(BaseShip &ship, float dt) override;

--- a/src/core/AI/StrafeAndShootBehavior.h
+++ b/src/core/AI/StrafeAndShootBehavior.h
@@ -32,6 +32,13 @@ class StrafeAndShootBehavior : public IBehavior
     StrafeAndShootBehavior();
     ~StrafeAndShootBehavior() override = default;
 
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    StrafeAndShootBehavior(const StrafeAndShootBehavior &) = delete;
+    StrafeAndShootBehavior &operator=(const StrafeAndShootBehavior &) = delete;
+
+    StrafeAndShootBehavior(StrafeAndShootBehavior &&) = delete;
+    StrafeAndShootBehavior &operator=(StrafeAndShootBehavior &&) = delete;
+
   protected:
     // IBehavior hooks
     void UpdateMovementLogic(BaseShip &ship, float dt) override;

--- a/src/core/common/Assets.h
+++ b/src/core/common/Assets.h
@@ -527,6 +527,7 @@ static const std::unordered_map<std::string, std::string> Sprites = {
     {"AlienShip", "assets/sprites/enemies/AlienShip.png"},
     {"BerserkerShip", "assets/sprites/enemies/BerserkerShip.png"},
     {"CrusaderShip", "assets/sprites/enemies/CrusaderShip.png"},
+    {"GruntShip", "assets/sprites/enemies/GruntShip.png"},
     {"AstronautSpeakerBlack", "assets/sprites/players/AstronautSpeakerBlack.png"},
     {"AstronautSpeakerBlue", "assets/sprites/players/AstronautSpeakerBlue.png"},
     {"AstronautSpeakerGold", "assets/sprites/players/AstronautSpeakerGold.png"},

--- a/src/core/managers/ShipManager.cpp
+++ b/src/core/managers/ShipManager.cpp
@@ -103,6 +103,14 @@ void ShipManager::SpawnCrusaderEnemy(const sf::Vector2f &pos)
     m_enemies.push_back(enemy);
 }
 
+/// @brief Creates a GruntShip object to be managed by ShipManager.
+/// @param pos Coordinate position to spawn at.
+void ShipManager::SpawnGruntEnemy(const sf::Vector2f &pos)
+{
+    auto enemy = ShipFactory::Instance().CreateGruntShip(pos, Allegiance::Enemy);
+    m_enemies.push_back(enemy);
+}
+
 /// @brief Returns a reference to the PlayerShip.
 /// @return Safe pointer to m_player.
 std::shared_ptr<PlayerShip> ShipManager::GetPlayer() const

--- a/src/core/managers/ShipManager.h
+++ b/src/core/managers/ShipManager.h
@@ -42,6 +42,7 @@ class ShipManager
     void SpawnAlienEnemy(const sf::Vector2f &pos);
     void SpawnBerserkerEnemy(const sf::Vector2f &pos);
     void SpawnCrusaderEnemy(const sf::Vector2f &pos);
+    void SpawnGruntEnemy(const sf::Vector2f &pos);
 
     std::shared_ptr<PlayerShip> GetPlayer() const;
     const std::vector<std::shared_ptr<BaseShip>> &GetEnemies() const;

--- a/src/core/scenes/SandBoxScene.cpp
+++ b/src/core/scenes/SandBoxScene.cpp
@@ -335,7 +335,8 @@ void SandBoxScene::SetupSceneComponents()
     MockBasicShipTest(false);
     MockAlienShipTest(false);
     MockBerserkerShipTest(false);
-    MockCrusaderShipTest(true);
+    MockCrusaderShipTest(false);
+    MockGruntShipTest(true);
 }
 
 /// @brief Helper method to create the Title string entity for this scene.
@@ -613,6 +614,21 @@ void SandBoxScene::MockCrusaderShipTest(const bool enabled)
     const auto winSize = WindowManager::Instance().GetWindow().getSize();
 
     ShipManager::Instance().SpawnCrusaderEnemy({winSize.x * .30f, 25.f});
+}
+
+/// @brief Mock enemy units to spawn. Specifically call for GruntShip.
+/// @param enabled is enabled or not
+void SandBoxScene::MockGruntShipTest(const bool enabled)
+{
+    if (!enabled)
+    {
+        return;
+    }
+
+    const auto winSize = WindowManager::Instance().GetWindow().getSize();
+
+    ShipManager::Instance().SpawnGruntEnemy({winSize.x * .15f, 25.f});
+    ShipManager::Instance().SpawnGruntEnemy({winSize.x * .70f, 25.f});
 }
 
 /// @brief Mock player test

--- a/src/core/scenes/SandBoxScene.h
+++ b/src/core/scenes/SandBoxScene.h
@@ -72,6 +72,7 @@ class SandBoxScene final : public Scene
     void MockAlienShipTest(const bool enabled);
     void MockBerserkerShipTest(const bool enabled);
     void MockCrusaderShipTest(const bool enabled);
+    void MockGruntShipTest(const bool enabled);
 
     void MockPlayerUnit(const bool enabled);
 

--- a/src/core/ships/AlienShip.cpp
+++ b/src/core/ships/AlienShip.cpp
@@ -17,6 +17,7 @@
 #include "ProjectileManager.h"
 #include "ResolutionScaleManager.h"
 #include "SettingsManager.h"
+#include "ShipStatsScaling.h"
 #include "WindowManager.h"
 #include <random>
 
@@ -67,9 +68,9 @@ AlienShip::AlienShip(const sf::Vector2f &startPos, Allegiance allegiance) : m_rn
 
         m_currentDirection = m_directionDist(m_rng) == 0 ? -1.f : 1.f;
 
-        m_health = m_maxHealth = ScaleHealthToDifficulty(ALIEN_BASE_HEALTH);
-        m_speed = ScaleSpeedToDifficulty(ALIEN_BASE_SPEED);
-        SetSpriteColorFromDifficulty(m_sprite);
+        m_health = m_maxHealth = ShipStatsScaling::ScaleHealthToDifficulty(ALIEN_BASE_HEALTH);
+        m_speed = ShipStatsScaling::ScaleSpeedToDifficulty(ALIEN_BASE_SPEED);
+        ShipStatsScaling::SetSpriteColorFromDifficulty(m_sprite);
         InitializeGunStats();
     }
 

--- a/src/core/ships/AlienShip.h
+++ b/src/core/ships/AlienShip.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "BaseShip.h"
-#include "ShipStatsScaling.h"
 #include "StrafeAndShootBehavior.h"
 #include <random>
 
@@ -26,7 +25,7 @@
 //      - Update position and aliveness for this spaceship.
 //
 // ============================================================================
-class AlienShip : public BaseShip, public ShipStatsScaling, public StrafeAndShootBehavior
+class AlienShip : public BaseShip, public StrafeAndShootBehavior
 {
   public:
     AlienShip(const sf::Vector2f &startPos, Allegiance allegiance);

--- a/src/core/ships/BasicShip.cpp
+++ b/src/core/ships/BasicShip.cpp
@@ -15,6 +15,7 @@
 #include "Macros.h"
 #include "ResolutionScaleManager.h"
 #include "SettingsManager.h"
+#include "ShipStatsScaling.h"
 #include "WindowManager.h"
 
 /// @brief Constants that can be adjusted throughout the BasicShip.
@@ -41,9 +42,9 @@ BasicShip::BasicShip(const sf::Vector2f &startPos, Allegiance allegiance)
         m_sprite.setOrigin(tex->getSize().x / 2.f, tex->getSize().y / 2.f);
         m_allegiance = allegiance;
 
-        m_health = m_maxHealth = ScaleHealthToDifficulty(BASE_HEALTH);
-        m_speed = ScaleSpeedToDifficulty(BASE_SPEED);
-        SetSpriteColorFromDifficulty(m_sprite);
+        m_health = m_maxHealth = ShipStatsScaling::ScaleHealthToDifficulty(BASE_HEALTH);
+        m_speed = ShipStatsScaling::ScaleSpeedToDifficulty(BASE_SPEED);
+        ShipStatsScaling::SetSpriteColorFromDifficulty(m_sprite);
     }
 
     else

--- a/src/core/ships/BasicShip.h
+++ b/src/core/ships/BasicShip.h
@@ -13,7 +13,6 @@
 
 #include "BaseShip.h"
 #include "DrifterBehavior.h"
-#include "ShipStatsScaling.h"
 
 // ============================================================================
 //  Class       : BasicShip
@@ -24,7 +23,7 @@
 //      - Update position and aliveness for this spaceship.
 //
 // ============================================================================
-class BasicShip : public BaseShip, public ShipStatsScaling, public DrifterBehavior
+class BasicShip : public BaseShip, public DrifterBehavior
 {
   public:
     BasicShip(const sf::Vector2f &startPos, Allegiance allegiance);

--- a/src/core/ships/BerserkerShip.cpp
+++ b/src/core/ships/BerserkerShip.cpp
@@ -44,7 +44,7 @@ BerserkerShip::BerserkerShip(const sf::Vector2f &startPos, Allegiance allegiance
 
     if (!tex)
     {
-        CT_LOG_ERROR("BerserkerShip texture not found: EnemyAssets::BerserkerShipSpriteKey");
+        CT_LOG_ERROR("BerserkerShip texture not found.");
 
         return;
     }

--- a/src/core/ships/BerserkerShip.cpp
+++ b/src/core/ships/BerserkerShip.cpp
@@ -12,6 +12,7 @@
 #include "Assets.h"
 #include "Macros.h"
 #include "ShipManager.h"
+#include "ShipStatsScaling.h"
 #include "WindowManager.h"
 
 /// @brief Constants that can be adjusted throughout the BerserkerShip.
@@ -53,9 +54,9 @@ BerserkerShip::BerserkerShip(const sf::Vector2f &startPos, Allegiance allegiance
     m_sprite.setOrigin(tex->getSize().x / 2.f, tex->getSize().y / 2.f);
     m_allegiance = allegiance;
 
-    m_health = m_maxHealth = ScaleHealthToDifficulty(BERSERKER_BASE_HEALTH);
-    m_speed = ScaleSpeedToDifficulty(BERSERKER_BASE_SPEED);
-    SetSpriteColorFromDifficulty(m_sprite);
+    m_health = m_maxHealth = ShipStatsScaling::ScaleHealthToDifficulty(BERSERKER_BASE_HEALTH);
+    m_speed = ShipStatsScaling::ScaleSpeedToDifficulty(BERSERKER_BASE_SPEED);
+    ShipStatsScaling::SetSpriteColorFromDifficulty(m_sprite);
 
     InitializeGunStats();
 }

--- a/src/core/ships/BerserkerShip.h
+++ b/src/core/ships/BerserkerShip.h
@@ -6,7 +6,6 @@
 //  Description : Fast kamikaze ship. Locks direction to player's position at
 //                spawn and flies straight along that vector (no homing).
 //
-//
 //  License     : N/A Open source
 //                Copyright (c) 2025 Mario Migliacio
 // ============================================================================
@@ -15,7 +14,6 @@
 
 #include "BaseShip.h"
 #include "BerserkerBehavior.h"
-#include "ShipStatsScaling.h"
 
 // ============================================================================
 //  Class       : BerserkerShip
@@ -27,7 +25,7 @@
 //      - Update position and aliveness for this spaceship.
 //
 // ============================================================================
-class BerserkerShip : public BaseShip, public ShipStatsScaling, public BerserkerBehavior
+class BerserkerShip : public BaseShip, public BerserkerBehavior
 {
   public:
     BerserkerShip(const sf::Vector2f &startPos, Allegiance allegiance);

--- a/src/core/ships/CrusaderShip.cpp
+++ b/src/core/ships/CrusaderShip.cpp
@@ -49,7 +49,7 @@ CrusaderShip::CrusaderShip(const sf::Vector2f &startPos, Allegiance allegiance)
 
     if (!tex)
     {
-        CT_LOG_ERROR("CrusaderShip texture not found: EnemyAssets::CrusaderShipSpriteKey");
+        CT_LOG_ERROR("CrusaderShip texture not found.");
 
         return;
     }

--- a/src/core/ships/CrusaderShip.cpp
+++ b/src/core/ships/CrusaderShip.cpp
@@ -15,6 +15,7 @@
 #include "Assets.h"
 #include "EnemyGun.h"
 #include "Macros.h"
+#include "ShipStatsScaling.h"
 #include "WindowManager.h"
 
 /// @brief Constants that can be adjusted throughout the CrusaderShip.
@@ -58,9 +59,9 @@ CrusaderShip::CrusaderShip(const sf::Vector2f &startPos, Allegiance allegiance)
     m_sprite.setOrigin(tex->getSize().x * 0.5f, tex->getSize().y * 0.5f);
     m_allegiance = allegiance;
 
-    m_health = m_maxHealth = ScaleHealthToDifficulty(CRUSADER_BASE_HEALTH);
-    m_speed = ScaleSpeedToDifficulty(CRUSADER_BASE_SPEED);
-    SetSpriteColorFromDifficulty(m_sprite);
+    m_health = m_maxHealth = ShipStatsScaling::ScaleHealthToDifficulty(CRUSADER_BASE_HEALTH);
+    m_speed = ShipStatsScaling::ScaleSpeedToDifficulty(CRUSADER_BASE_SPEED);
+    ShipStatsScaling::SetSpriteColorFromDifficulty(m_sprite);
 
     InitializeGunStats();
 }

--- a/src/core/ships/CrusaderShip.h
+++ b/src/core/ships/CrusaderShip.h
@@ -13,7 +13,6 @@
 #pragma once
 #include "BaseShip.h"
 #include "CrusaderBehavior.h"
-#include "ShipStatsScaling.h"
 
 // ============================================================================
 //  Class       : CrusaderShip
@@ -26,7 +25,7 @@
 //      - Update position and aliveness for this spaceship.
 //
 // ============================================================================
-class CrusaderShip : public BaseShip, public ShipStatsScaling, public CrusaderBehavior
+class CrusaderShip : public BaseShip, public CrusaderBehavior
 {
   public:
     CrusaderShip(const sf::Vector2f &startPos, Allegiance allegiance);

--- a/src/core/ships/GruntShip.cpp
+++ b/src/core/ships/GruntShip.cpp
@@ -1,0 +1,98 @@
+// ============================================================================
+//  File        : GruntShip.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-09-05
+//  Description : A small unit that hops locally and fires aimed shots.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#include "GruntShip.h"
+#include "AssetManager.h"
+#include "Assets.h"
+#include "DodgeAndAimBehavior.h"
+#include "EnemyGun.h"
+#include "Macros.h"
+#include "ShipStatsScaling.h"
+#include "WindowManager.h"
+
+/// @brief Constants that can be adjusted throughout the GruntShip.
+namespace
+{
+/// @brief Base Health before scaling.
+constexpr int GRUNT_BASE_HEALTH = 20;
+
+/// @brief Base Speed before scaling.
+const sf::Vector2f GRUNT_BASE_SPEED = {0.f, 110.f};
+
+/// @brief Configurable constant for Gun FireRate.
+constexpr float GRUNT_BASE_FIRERATE = 1.0f;
+
+/// @brief Configurable constant for Gun Damage.
+constexpr float GRUNT_BULLET_DAMAGE = 9.f;
+
+/// @brief Configurable constant for Gun Speed.
+constexpr float GRUNT_BULLET_SPEED = 350.f;
+
+/// @brief Configurable constant for Gun Projectile color.
+const sf::Color GRUNT_BULLET_COLOR = sf::Color::Red;
+} // namespace
+
+/// @brief Constructor for a GruntShip type of ship.
+/// @param startPos Position to emplace at.
+/// @param allegiance Allegiance to employ with.
+GruntShip::GruntShip(const sf::Vector2f &startPos, Allegiance allegiance)
+{
+    auto tex = AssetManager::Instance().GetTexture(SpriteAssets::EnemyAssets::GruntShipSpriteKey);
+
+    if (!tex)
+    {
+        CT_LOG_ERROR("GruntShip texture not found.");
+
+        return;
+    }
+
+    m_sprite.setTexture(*tex);
+    m_sprite.setPosition(startPos);
+    m_sprite.setOrigin(tex->getSize().x * 0.5f, tex->getSize().y * 0.5f);
+    m_allegiance = allegiance;
+
+    m_health = m_maxHealth = ShipStatsScaling::ScaleHealthToDifficulty(GRUNT_BASE_HEALTH);
+    m_speed = ShipStatsScaling::ScaleSpeedToDifficulty(GRUNT_BASE_SPEED);
+    ShipStatsScaling::SetSpriteColorFromDifficulty(m_sprite);
+
+    InitializeGunStats();
+}
+
+/// @brief Performs internal state management during a single frame.
+/// @param dt delta time since last update frame.
+void GruntShip::Update(float dt)
+{
+    if (!m_alive)
+    {
+        return;
+    }
+
+    UpdateBehavior(*this, dt);
+    CullIfOffscreen();
+}
+
+/// @brief Initialize gun stats
+void GruntShip::InitializeGunStats()
+{
+    ProjectileStats s{};
+    m_gunStats.fireRate = GRUNT_BASE_FIRERATE;
+    m_gunStats.damage = GRUNT_BULLET_DAMAGE;
+    m_gunStats.speed = GRUNT_BULLET_SPEED;
+    m_gunStats.tint = GRUNT_BULLET_COLOR;
+    m_gunStats.homing = false;
+
+    m_gun = std::make_unique<EnemyGun>(s);
+
+    const sf::Vector2f spriteSize(static_cast<float>(m_sprite.getTexture()->getSize().x),
+                                  static_cast<float>(m_sprite.getTexture()->getSize().y));
+
+    m_gun->SetAllegiance(Allegiance::Enemy, spriteSize);
+}

--- a/src/core/ships/GruntShip.h
+++ b/src/core/ships/GruntShip.h
@@ -1,0 +1,44 @@
+// ============================================================================
+//  File        : GruntShip.h
+//  Project     : ChaosTheory (CT)
+//  Author      : Mario Migliacio
+//  Created     : 2025-09-05
+//  Description : A small unit that hops locally and fires aimed shots.
+//
+//  License     : N/A Open source
+//                Copyright (c) 2025 Mario Migliacio
+// ============================================================================
+
+#pragma once
+
+#include "Allegiance.h"
+#include "BaseShip.h"
+#include "DodgeAndAimBehavior.h"
+
+// ============================================================================
+//  Class       : GruntShip
+//  Purpose     : A travelling spaceship that hops to a random local location,
+//                shoots a directed shot towards the player, and then cools
+//                down by travelling downwards until dead or off screen.
+//
+//  Responsibilities:
+//      - Scale upon construction based on game difficulty and window size.
+//      - Update position and aliveness for this spaceship.
+//
+// ============================================================================
+class GruntShip : public BaseShip, public DodgeAndAimBehavior
+{
+  public:
+    GruntShip(const sf::Vector2f &startPos, Allegiance allegiance);
+    ~GruntShip() override = default;
+
+    // Disallow copy and move semantics to avoid shallow copies or misuse
+    GruntShip(const GruntShip &) = delete;
+    GruntShip &operator=(const GruntShip &) = delete;
+
+  public:
+    void Update(float dt) override;
+
+  private:
+    void InitializeGunStats();
+};

--- a/src/core/ships/PlayerShip.cpp
+++ b/src/core/ships/PlayerShip.cpp
@@ -90,7 +90,7 @@ PlayerShip::PlayerShip()
 
     else
     {
-        CT_LOG_ERROR("PlayerShip: ERROR - texture not found.");
+        CT_LOG_ERROR("PlayerShip texture not found.");
     }
 }
 

--- a/src/core/ships/ShipFactory.cpp
+++ b/src/core/ships/ShipFactory.cpp
@@ -16,6 +16,7 @@
 #include "BasicShip.h"
 #include "BerserkerShip.h"
 #include "CrusaderShip.h"
+#include "GruntShip.h"
 #include "Macros.h"
 #include "PlayerShip.h"
 #include "ResolutionScaleManager.h"
@@ -173,6 +174,37 @@ std::shared_ptr<BaseShip> ShipFactory::CreateCrusaderShip(const sf::Vector2f &po
     else
     {
         CT_LOG_ERROR("ShipFactory-CrusaderShip texture not found during creation!");
+    }
+
+    return ship;
+}
+
+/// @brief Creates a GruntShip, scaled appropriately with the window resolution.
+/// @param pos Starting position to emplace ship at.
+/// @param allegiance Allegiance to employ ship with.
+/// @return Safe pointer to a GruntShip, compatible with the BaseShip base class.
+std::shared_ptr<BaseShip> ShipFactory::CreateGruntShip(const sf::Vector2f &pos, Allegiance allegiance)
+{
+    auto ship = std::make_shared<GruntShip>(pos, allegiance);
+
+    // Setup resolution-based scaling
+    auto tex = AssetManager::Instance().GetTexture(SpriteAssets::EnemyAssets::GruntShipSpriteKey);
+
+    if (tex)
+    {
+        // A little redundant to getSize.x and getSize.y because GruntShip is a square. But explicit.
+        float textureWidth = static_cast<float>(tex->getSize().x);
+        float textureHeight = static_cast<float>(tex->getSize().y);
+        float scaledWidth = ResolutionScaleManager::Instance().ScaleX(textureWidth);
+        float scaledHeight = ResolutionScaleManager::Instance().ScaleY(textureHeight);
+        float scaleFactorX = scaledWidth / textureWidth;
+        float scaleFactorY = scaledHeight / textureHeight;
+        ship->SetScale(scaleFactorX, scaleFactorY);
+    }
+
+    else
+    {
+        CT_LOG_ERROR("ShipFactory-GruntShip texture not found during creation!");
     }
 
     return ship;

--- a/src/core/ships/ShipFactory.h
+++ b/src/core/ships/ShipFactory.h
@@ -32,6 +32,7 @@ class ShipFactory
     std::shared_ptr<BaseShip> CreateAlienShip(const sf::Vector2f &pos, Allegiance allegiance);
     std::shared_ptr<BaseShip> CreateBerserkerShip(const sf::Vector2f &pos, Allegiance allegiance);
     std::shared_ptr<BaseShip> CreateCrusaderShip(const sf::Vector2f &pos, Allegiance allegiance);
+    std::shared_ptr<BaseShip> CreateGruntShip(const sf::Vector2f &pos, Allegiance allegiance);
 
   private:
     ShipFactory() = default;

--- a/src/core/ships/ShipStatsScaling.h
+++ b/src/core/ships/ShipStatsScaling.h
@@ -3,7 +3,7 @@
 //  Project     : ChaosTheory (CT)
 //  Author      : Mario Migliacio
 //  Created     : 2025-07-31
-//  Description : Provides an easy interface for Enemy ships to inherit for scaling.
+//  Description : Provides an easy interface for Enemy ships to scale.
 
 //  License     : N/A Open source
 //                Copyright (c) 2025 Mario Migliacio
@@ -14,7 +14,7 @@
 #include "ResolutionScaleManager.h"
 #include "SettingsManager.h"
 
-/// @brief Constants that can be adjusted throughout the AlienShip.
+/// @brief Constants that can be adjusted throughout the Ship.
 namespace
 {
 /// @brief Health scaling factor for Easy game difficulty.
@@ -59,7 +59,7 @@ class ShipStatsScaling
     /// @brief Scales health accordingly based on GameDifficulty.
     /// @param value health to scale.
     /// @return new health after scaling applied.
-    int ScaleHealthToDifficulty(const int value)
+    static int ScaleHealthToDifficulty(const int value)
     {
         int health = 0;
         const auto difficulty = SettingsManager::Instance().GetSettings()->m_gameDifficulty;
@@ -88,7 +88,7 @@ class ShipStatsScaling
     /// @brief Scales speed accordingly based on WindowResolution, and GameDifficulty.
     /// @param value speed to scale.
     /// @return new speed after scaling applied.
-    sf::Vector2f ScaleSpeedToDifficulty(const sf::Vector2f &value)
+    static sf::Vector2f ScaleSpeedToDifficulty(const sf::Vector2f &value)
     {
         sf::Vector2f speed = {0.f, 0.f};
         const auto difficulty = SettingsManager::Instance().GetSettings()->m_gameDifficulty;
@@ -119,7 +119,7 @@ class ShipStatsScaling
 
     /// @brief Sets the appropriate tint to the Sprite based on GameDifficulty.
     /// @param sprite The sprite to alter the tint for.
-    void SetSpriteColorFromDifficulty(sf::Sprite &sprite)
+    static void SetSpriteColorFromDifficulty(sf::Sprite &sprite)
     {
         const auto difficulty = SettingsManager::Instance().GetSettings()->m_gameDifficulty;
 

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -18,7 +18,7 @@
 #define CT_VERSION_MINOR 5
 
 /// @brief Patch Version of Chaos Theory to date.
-#define CT_VERSION_PATCH 6
+#define CT_VERSION_PATCH 7
 
 // Helper macros to convert numbers to strings
 #define CT_STRINGIFY(x) #x


### PR DESCRIPTION
patched:  v1.5.7-Grunt
		- Added GruntShip to ChaosTheory
		- Create behavior for Grunt
		- Create GruntShip
		- Add in factory hook
		- Add in ShipManager hook
		- Update Sandbox to mock and inspect
		- Updated ShipStatsScaling to be simpler, static methods called basically same way but ships no longer have to inherit it.
		- Cleaned up constructor and copy constructors for behaviors to be more consistent.